### PR TITLE
NEST device protocols

### DIFF
--- a/tests/configs/test_recorders.json
+++ b/tests/configs/test_recorders.json
@@ -1,0 +1,106 @@
+{
+  "name": "DBBS Mouse cerebellum configuration v4.0",
+  "output": {
+    "format": "bsb.output.HDF5Formatter",
+    "file": "single_neuron_test.hdf5"
+  },
+  "network_architecture": {
+    "simulation_volume_x": 150.0,
+    "simulation_volume_z": 150.0,
+    "store_kd_trees": true,
+    "store_compound_kd_tree": true,
+    "store_pf_kd_trees": true
+  },
+  "layers": {
+    "test_layer": {
+      "thickness": 600,
+      "stack": {
+        "stack_id": 0,
+        "position_in_stack": 0,
+        "position": [0.0, 0.0, 0.0]
+      }
+    }
+  },
+  "cell_types": {
+    "test_cell": {
+      "placement": {
+        "class": "bsb.placement.ParticlePlacement",
+        "layer": "test_layer",
+        "soma_radius": 2.5,
+        "count": 4
+      },
+      "morphology": {
+        "class": "bsb.morphologies.NoGeometry"
+      },
+      "plotting": {
+        "display_name": "lonely cell",
+        "color": "#E62214"
+      }
+    }
+  },
+  "connection_types": {
+
+  },
+  "simulations": {
+    "test_recorders": {
+      "simulator": "nest",
+      "default_neuron_model": "iaf_cond_alpha",
+      "default_synapse_model": "static_synapse",
+      "duration": 10,
+      "cell_models": {
+        "test_cell": {
+          "parameters": {
+            "t_ref": 1.5,
+            "C_m": 7.0,
+            "V_th": -41.0,
+            "V_reset": -70.0,
+            "E_L": -62.0
+          },
+          "iaf_cond_alpha": {
+            "I_e": 0.0
+          },
+          "eglif_cond_alpha_multisyn": {
+            "Vinit": -62.0,
+            "lambda_0":1.0,
+            "tau_V":0.3,
+            "tau_m": 24.15,
+            "I_e": -0.888,
+            "kadap": 0.022,
+            "k1": 0.311,
+            "k2": 0.041,
+            "A1": 0.01,
+            "A2":-0.94
+          }
+        }
+      },
+      "connection_models": {
+
+      },
+      "devices": {
+        "gen": {
+          "device": "poisson_generator",
+          "io": "input",
+          "type": "cell_type",
+          "cell_types": ["test_cell"],
+          "parameters": {
+            "rate": 1.0,
+            "start": 0.0,
+            "stop": 1000.0
+          }
+        },
+        "record_spikes": {
+          "device": "spike_detector",
+          "io": "output",
+          "type": "cell_type",
+          "cell_types": ["test_cell"],
+          "parameters": {
+            "withgid": true,
+            "withtime": true,
+            "to_file": true,
+            "label": "test_spikes"
+          }
+        },
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Describe the work done

I added `DeviceProtocol`s so that we can create optional thin wrappers around the nest devices. These device protocols provide extra hooks into the lifecycle of devices. My main usecase for now is to create `SimulationRecorder`s (see the `simulation-recorders` branch) so that the GDF data is collected into the final HDF5 file. But I'm sure we'll find more uses for these protocols in the future.

You can create your own DeviceProtocol by making a class that inherits from it and defining implementations of the callback functions. Then map the name of the nest device model to the class object in `_device_protocols` at the bottom of `nest.py`:

```python
class MyDeviceProtocol(DeviceProtocol):
  def before_create(self):
    print(self.device.name, "is being created")

_device_protocols = {
  # ...
  'nest_model': MyDeviceProtocol
}
```

## Tasks

* [x] Added tests
* [x] Updated documentation (it's an implementation, no docs required)
