### PR TITLE
Rectify difference between threads (OpenMP) and processes (MPI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,10 @@ When modifying the config object through scripts and then saving it to file, you
 the original configuration file text, and you won't actually serialize the modified object
 
 We will fix this by version 4.0
+
+## If MPI is installed but mpi4py is not undefined behavior may occur
+
+The amount of NEST virtual processes is determined by using mpi4py to get the amount of
+MPI processes. But if the package is not installed it is assumed no MPI simulations will
+be ran and the amount of virtual processes might be lower than expected when used in
+combination with OpenMP. Be sure to `pip install` using the `[MPI]` requirement tag.

--- a/bsb/simulators/nest.py
+++ b/bsb/simulators/nest.py
@@ -289,7 +289,6 @@ class NestAdapter(SimulatorAdapter):
         "default_synapse_model": "static_synapse",
         "default_neuron_model": "iaf_cond_alpha",
         "verbosity": "M_ERROR",
-        "nodes": 1,
         "threads": 1,
         "resolution": 1.0,
         "modules": [],

--- a/bsb/simulators/nest.py
+++ b/bsb/simulators/nest.py
@@ -11,7 +11,13 @@ from ..exceptions import *
 import os, json, weakref, numpy as np
 from itertools import chain
 from sklearn.neighbors import KDTree
-import mpi4py.MPI
+
+try:
+    import mpi4py.MPI
+
+    _MPI_processes = mpi4py.MPI.COMM_WORLD.Get_size()
+except ImportError:
+    _MPI_processes = 1
 
 LOCK_ATTRIBUTE = "dbbs_scaffold_lock"
 
@@ -442,7 +448,7 @@ class NestAdapter(SimulatorAdapter):
 
     def reset_processes(self, threads):
         master_seed = self.get_master_seed()
-        total_num = mpi4py.MPI.COMM_WORLD.Get_size() * threads
+        total_num = _MPI_processes * threads
         # Create a range of random seeds and generators.
         random_generator_seeds = range(master_seed, master_seed + total_num)
         # Create a different range of random seeds for the kernel.

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,6 @@ setuptools.setup(
     extras_require={
         "dev": ["sphinx", "sphinx_rtd_theme>=0.4.3", "pyarmor", "pre-commit", "black"],
         "NEURON": ["dbbs_models>=0.4.4"],
+        "MPI": ["mpi4py"],
     },
 )


### PR DESCRIPTION
## Describe the work done

So guys (@alberto-antonietti, @AliceGem), when we do `mpiexec -n 4`, 4 MPI processes are created. If we set `local_num_threads = 1` this should result in 4 virtual processes, 1 on each MPI process and no multithreading should occur. For some reason though if you use `GetKernelStatus` the `total_num_virtual_procs` will be 1 unless it is explicitly set, like in the examples [here](https://nest-simulator.readthedocs.io/en/stable/guides/parallel_computing.html#reproducibility). I've [asked](https://stackoverflow.com/questions/63729214/why-is-total-num-virtual-procs-not-equal-to-the-amount-of-mpi-processes) why with 4 MPI processes the `total_num_virtual_procs` could ever be `1`. If this is really so this would mean that 3 MPI processes contain 0 virtual processes and are doing nothing at all, and are not part of the simulation!

Until a clear answer is given by someone on the NEST team I've changed the code to use the MPI world size (`mpi4py.MPI.COMM_WORLD.Get_size()`)  to determine and explicitly set `total_num_virtual_procs` to the amount of MPI processes multiplied by the requested amount of threads per process (`self.threads`):

```python
            total_num = mpi4py.MPI.COMM_WORLD.Get_size() * threads
            # ...
            self.nest.SetKernelStatus(
                {
                    # ...
                    "local_num_threads": threads,
                    "total_num_virtual_procs": total_num,
                }
            )
```

This should put the eternal question of "WTF are processes, virtual processes & threads" to bed and allow the user to run their parallel simulations with `mpiexec -n 42` without settings anything in the config.

## List which issues this resolves:

closes #61
