### PR TITLE
Implemented unbuffered output

### DIFF
--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -1,6 +1,7 @@
 import warnings, base64
 
 warnings.filterwarnings("once", category=DeprecationWarning)
+sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), 'wb', 0), write_through=True)
 
 _verbosity = 1
 _report_file = None

--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -1,7 +1,7 @@
 import warnings, base64
 
 warnings.filterwarnings("once", category=DeprecationWarning)
-sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), 'wb', 0), write_through=True)
+sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), "wb", 0), write_through=True)
 
 _verbosity = 1
 _report_file = None

--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -1,4 +1,4 @@
-import warnings, base64
+import warnings, base64, io
 
 warnings.filterwarnings("once", category=DeprecationWarning)
 sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), "wb", 0), write_through=True)

--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -1,4 +1,4 @@
-import warnings, base64, io
+import warnings, base64, io, sys
 
 warnings.filterwarnings("once", category=DeprecationWarning)
 sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), "wb", 0), write_through=True)


### PR DESCRIPTION
## Describe the work done

`sys.stdout` is replaced by an unbuffered variant, so that no matter the environment, output can be printed in realtime in MPI simulations.

## List which issues this resolves:

closes #51
