### PR TITLE
Solved display of upstream DeprecationWarnings

### DIFF
--- a/bsb/core.py
+++ b/bsb/core.py
@@ -131,7 +131,7 @@ class Scaffold:
             :param ongoing: The message is part of an ongoing progress report. This replaces the endline (`\\n`) character with a carriage return (`\\r`) character
             :deprecated: Use :func:`.reporting.report`
         """
-        std_warn("Deprecated in favor of `bsb.reporting.report`.", DeprecationWarning)
+        std_warn("Deprecated in favor of `bsb.reporting.report`.", UserDeprecationWarning)
         report(message, level=level, ongoing=ongoing)
 
     def warn(self, message, category=None):
@@ -143,7 +143,7 @@ class Scaffold:
             :param category: The class of the warning.
             :deprecated: Use :func:`.reporting.warn`
         """
-        std_warn("Deprecated in favor of `bsb.reporting.warn`.", DeprecationWarning)
+        std_warn("Deprecated in favor of `bsb.reporting.warn`.", UserDeprecationWarning)
         warn(message, category)
 
     def _intialise_simulators(self):

--- a/bsb/exceptions.py
+++ b/bsb/exceptions.py
@@ -180,6 +180,10 @@ class ConfigurationWarning(ScaffoldWarning):
     pass
 
 
+class UserUserDeprecationWarning(ScaffoldWarning):
+    pass
+
+
 class PlacementWarning(ScaffoldWarning):
     pass
 

--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -1,6 +1,6 @@
 import warnings, base64, io, sys
 
-sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), 'wb', 0), write_through=True)
+sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), "wb", 0), write_through=True)
 
 _verbosity = 1
 _report_file = None

--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -1,7 +1,6 @@
 import warnings, base64, io, sys
 
-warnings.filterwarnings("once", category=DeprecationWarning)
-sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), "wb", 0), write_through=True)
+sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), 'wb', 0), write_through=True)
 
 _verbosity = 1
 _report_file = None

--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -1,6 +1,7 @@
 import warnings, base64
 
 warnings.filterwarnings("once", category=DeprecationWarning)
+sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), 'wb', 0), write_through=True)
 
 _verbosity = 1
 _report_file = None

--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -1,7 +1,7 @@
 import warnings, base64
 
 warnings.filterwarnings("once", category=DeprecationWarning)
-sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), 'wb', 0), write_through=True)
+sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), "wb", 0), write_through=True)
 
 _verbosity = 1
 _report_file = None

--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -1,4 +1,4 @@
-import warnings, base64
+import warnings, base64, io
 
 warnings.filterwarnings("once", category=DeprecationWarning)
 sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), "wb", 0), write_through=True)

--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -1,4 +1,4 @@
-import warnings, base64, io
+import warnings, base64, io, sys
 
 warnings.filterwarnings("once", category=DeprecationWarning)
 sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), "wb", 0), write_through=True)


### PR DESCRIPTION
## Describe the work done

I removed the filter that showed DeprecationWarnings once because it led to several DeprecationWarnings of upstream packages. Instead when we want to warn our users of deprecation we raise `UserDeprecationWarning`s