### PR TITLE
skip empty connectivity sets and raise a warning. closes #70

### DIFF
--- a/bsb/simulators/nest.py
+++ b/bsb/simulators/nest.py
@@ -638,6 +638,9 @@ class NestAdapter(SimulatorAdapter):
             postsynaptic_targets = np.array(
                 self.get_nest_ids(np.array(cs.to_identifiers, dtype=int))
             )
+            if not len(presynaptic_sources) or not len(postsynaptic_targets):
+                warn("No connections for " + name)
+                continue
             # Accessing the postsynaptic type to be associated to the volume transmitter of the synapse
             postsynaptic_type = cs.connection_types[0].to_cell_types[0]
             postsynaptic_cells = np.unique(postsynaptic_targets)


### PR DESCRIPTION
## Describe the work done

When an empty connectivty set is encountered the `nest.Connect` command threw an error. Empty connectivity sets are now skipped with a warning instead

## List which issues this resolves:

closes #70 
