### PR TITLE
Straightened out documentation build system

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
       run: sudo apt-get install -y openmpi-bin libopenmpi-dev
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install pip==20.0.1
         pip install -r requirements.txt --no-use-pep517
         pip install sphinx
     - name: Build documentations

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,8 +17,8 @@ jobs:
       run: sudo apt-get install -y openmpi-bin libopenmpi-dev
     - name: Install dependencies
       run: |
-        python -m pip install pip==20.0.1
-        pip install -r requirements.txt --no-use-pep517
+        python -m pip install pip
+        pip install -r docs/requirements.txt
         pip install sphinx
     - name: Build documentations
       run: cd docs && sphinx-build -n -b html source build/html

--- a/bsb/models.py
+++ b/bsb/models.py
@@ -14,6 +14,10 @@ from .exceptions import *
 
 
 class CellType(SortableByAfter):
+    """
+    A CellType represents a population of cells.
+    """
+
     def __init__(self, name, placement=None):
         self.name = name
         self.placement = placement
@@ -108,6 +112,11 @@ class CellType(SortableByAfter):
 
 
 class Layer(dimensions, origin):
+    """
+    A Layer represents a compartment of the topology of the simulation volume that slices
+    the volume in horizontally stacked portions.
+    """
+
     def __init__(self, name, origin, dimensions, scaling=True):
         # Name of the layer
         self.name = name

--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -68,7 +68,7 @@ def warn(message, category=None):
     Send a warning.
 
     :param message: Warning message
-    :type message: string
+    :type message: str
     :param category: The class of the warning.
     """
     if _verbosity > 0:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+sphinx==3.2.1
 sphinx_rtd_theme==0.4.3
 colour==0.1.5
 errr==0.2.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,3 @@
-h5py==2.10.0
-joblib==0.14.0
-numpy==1.17.3
-scikit-learn==0.21.3
-scipy==1.3.1
-six==1.12.0
-plotly==4.1.0
-pre-commit==1.21.0
-black==20.8b1
 sphinx_rtd_theme==0.4.3
 colour==0.1.5
 errr==0.2.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,7 @@ autodoc_mock_imports = [
     "sklearn",
     "sklearn.neighbors",
     "scipy",
+    "scipy.spatial",
     "six",
     "plotly",
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ autodoc_mock_imports = [
     "h5py",
     "joblib",
     "numpy",
-    "scikit-learn",
+    "sklearn",
     "scipy",
     "six",
     "plotly",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,6 +29,7 @@ autodoc_mock_imports = [
     "joblib",
     "numpy",
     "sklearn",
+    "sklearn.neighbors",
     "scipy",
     "six",
     "plotly",
@@ -44,9 +45,6 @@ class Mock(types.ModuleType):
 
     def __call__(self, *args, **kwargs):
         return 1
-
-    def __iter__(self):
-        yield Mock("iterated")
 
 
 for mod in autodoc_mock_imports:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,13 @@ autodoc_mock_imports = [
     "arborize",
     "rtree",
     "rtree.index",
+    "h5py",
+    "joblib",
+    "numpy",
+    "scikit-learn",
+    "scipy",
+    "six",
+    "plotly",
 ]
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,7 @@ import os
 import sys, types
 
 sys.path.insert(0, os.path.abspath("../.."))
+
 autodoc_mock_imports = [
     "glia",
     "patch",
@@ -29,34 +30,34 @@ autodoc_mock_imports = [
     "joblib",
     "numpy",
     "sklearn",
-    "sklearn.neighbors",
+    # "sklearn.neighbors",
     "scipy",
-    "scipy.spatial",
-    "scipy.stats",
-    "scipy.stats.distributions",
+    # "scipy.spatial",
+    # "scipy.stats",
+    # "scipy.stats.distributions",
     "six",
     "plotly",
-    "plotly.graph_objects",
-    "plotly.graph_objs",
-    "plotly.subplots",
+    # "plotly.graph_objects",
+    # "plotly.graph_objs",
+    # "plotly.subplots",
 ]
 
 
-class Mock(types.ModuleType):
-    def __repr__(self):
-        return "<mocked object '{}'>".format(self.__name__)
+# class Mock(types.ModuleType):
+#     def __repr__(self):
+#         return "<mocked object '{}'>".format(self.__name__)
+#
+#     def __getattr__(self, attr):
+#         return Mock("recursive")
+#
+#     def __call__(self, *args, **kwargs):
+#         return 1
+#
+#
+# for mod in autodoc_mock_imports:
+#     sys.modules[mod] = Mock(mod)
 
-    def __getattr__(self, attr):
-        return Mock("recursive")
-
-    def __call__(self, *args, **kwargs):
-        return 1
-
-
-for mod in autodoc_mock_imports:
-    sys.modules[mod] = Mock(mod)
-
-import bsb, bsb.config
+# import bsb, bsb.config
 
 
 # -- Project information -----------------------------------------------------
@@ -65,10 +66,17 @@ project = "DBBS Brain Scaffold Builder"
 copyright = "2020, Neurocomputational Lab, Department of Brain and Behavioral Sciences, University of Pavia"
 author = "Robin De Schepper et al., Neurocomputational Lab, University of Pavia"
 
+bsb_init_file = os.path.join(os.path.dirname(__file__), "..", "..", "bsb", "__init__.py")
+with open(bsb_init_file, "r") as f:
+    for line in f:
+        if "__version__ = " in line:
+            exec(line.strip())
+            break
+
 # The short X.Y version
-version = ".".join(bsb.__version__.split(".")[0:2])
+version = ".".join(__version__.split(".")[0:2])
 # The full version, including alpha/beta/rc tags
-release = bsb.__version__
+release = __version__
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,7 @@ autodoc_mock_imports = [
     "plotly",
     "plotly.graph_objects",
     "plotly.graph_objs",
+    "plotly.subplots",
 ]
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,6 +33,7 @@ autodoc_mock_imports = [
     "scipy",
     "scipy.spatial",
     "scipy.stats",
+    "scipy.stats.distributions",
     "six",
     "plotly",
     "plotly.graph_objects",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,9 @@ class Mock(types.ModuleType):
     def __call__(self, *args, **kwargs):
         return 1
 
+    def __iter__(self):
+        yield Mock("iterated")
+
 
 for mod in autodoc_mock_imports:
     sys.modules[mod] = Mock(mod)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,6 +32,7 @@ autodoc_mock_imports = [
     "sklearn.neighbors",
     "scipy",
     "scipy.spatial",
+    "scipy.stats",
     "six",
     "plotly",
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,34 +30,10 @@ autodoc_mock_imports = [
     "joblib",
     "numpy",
     "sklearn",
-    # "sklearn.neighbors",
     "scipy",
-    # "scipy.spatial",
-    # "scipy.stats",
-    # "scipy.stats.distributions",
     "six",
     "plotly",
-    # "plotly.graph_objects",
-    # "plotly.graph_objs",
-    # "plotly.subplots",
 ]
-
-
-# class Mock(types.ModuleType):
-#     def __repr__(self):
-#         return "<mocked object '{}'>".format(self.__name__)
-#
-#     def __getattr__(self, attr):
-#         return Mock("recursive")
-#
-#     def __call__(self, *args, **kwargs):
-#         return 1
-#
-#
-# for mod in autodoc_mock_imports:
-#     sys.modules[mod] = Mock(mod)
-
-# import bsb, bsb.config
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,8 @@ autodoc_mock_imports = [
     "scipy.stats",
     "six",
     "plotly",
+    "plotly.graph_objects",
+    "plotly.graph_objs",
 ]
 
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -18,8 +18,8 @@ The root node accepts the following attributes:
   files so it can be used for reference.
 * :guilabel:`output`: Configuration object for the output :class:`.output.HDF5Formatter`.
 * :guilabel:`network_architecture`: Configuration object for general simulation properties.
-* :guilabel:`layers`: A dictionary containing the :class:`bsb.models.Layer` configurations.
-* :guilabel:`cell_types`: A dictionary containing the :class:`bsb.models.CellType` configurations.
+* :guilabel:`layers`: A dictionary containing the :class:`.models.Layer` configurations.
+* :guilabel:`cell_types`: A dictionary containing the :class:`.models.CellType` configurations.
 * :guilabel:`connection_types`: A dictionary containing the :class:`.connectivity.ConnectionStrategy` configurations.
 * :guilabel:`simulations`: A dictionary containing the :class:`.simulation.SimulationAdapter` configurations.
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -117,6 +117,7 @@ The size of the Z dimension of the simulation volume.
   }
 
 .. note::
+
   The Y can not be set directly as it is a result of stacking/placing the layers.
   It's possible to place cells outside of the simulation volume, and even to place
   layers outside of the volume, but it is not recommended behavior. The X and Z
@@ -124,8 +125,9 @@ The size of the Z dimension of the simulation volume.
   simulation, but they aren't absolute restrictions.
 
 .. warning::
-  Do not modify these values directly on the configuration object: It will not
-  rescale your layers. Use :func:`resize <.configuration.ScaffoldConfig.resize>` instead.
+
+  Do not modify these values directly on the configuration object: It will not rescale
+  your layers. Use :func:`resize <bsb.configuration.ScaffoldConfig.resize>` instead.
 
 ================
 Layer attributes

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -18,8 +18,8 @@ The root node accepts the following attributes:
   files so it can be used for reference.
 * :guilabel:`output`: Configuration object for the output :class:`.output.HDF5Formatter`.
 * :guilabel:`network_architecture`: Configuration object for general simulation properties.
-* :guilabel:`layers`: A dictionary containing the :class:`.models.Layer` configurations.
-* :guilabel:`cell_types`: A dictionary containing the :class:`.models.CellType` configurations.
+* :guilabel:`layers`: A dictionary containing the :class:`bsb.models.Layer` configurations.
+* :guilabel:`cell_types`: A dictionary containing the :class:`bsb.models.CellType` configurations.
 * :guilabel:`connection_types`: A dictionary containing the :class:`.connectivity.ConnectionStrategy` configurations.
 * :guilabel:`simulations`: A dictionary containing the :class:`.simulation.SimulationAdapter` configurations.
 


### PR DESCRIPTION
## Describe the work done

Our docs setup was kind of fragile. I've removed the `import bsb, bsb.config` statement so that `conf.py` does not need to import them, and `autodoc_mock_imports` can be used again without the need of our own janky `Mock` class. Also removed the PEP517 flag and reduced the `docs/requirements.txt` to things that are actually required to build the docs. Specified `sphinx==3.2.1` so that we use a more modern sphinx version to build on RTD aswell. The reduced requirements allow both GitHub Actions and RTD to build quicker and without error.

_(Note to future self: see https://stackoverflow.com/questions/64241941/what-requirements-are-there-for-cross-referencing-a-python-object-in-sphinx for reference errors)_