### PR TITLE
synapses only on some dendritic labels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ jobs:
       python: 3.6
       before_install:
         - export NEST_INSTALL_DIR=/home/travis/nest-$NEST_VERSION
-        - wget https://neuron.yale.edu/ftp/neuron/versions/v7.7/nrn-7.7.x86_64-linux.deb
-        - sudo dpkg -i nrn-7.7.x86_64-linux.deb
-        - export PYTHONPATH=/usr/local/nrn/lib/python:$PYTHONPATH
 install:
   - source devops/check_nest_cache.sh
   - sudo apt-get install -y python3-rtree build-essential cmake cython libgsl-dev libltdl-dev libncurses-dev libreadline-dev openmpi-bin libopenmpi-dev

--- a/bsb/__init__.py
+++ b/bsb/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "3.6.0b1"
+__version__ = "3.6.0b3"
 
 from .reporting import set_verbosity, report, warn

--- a/bsb/__init__.py
+++ b/bsb/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "3.6.0b3"
+__version__ = "3.6.0b4"
 
 from .reporting import set_verbosity, report, warn

--- a/bsb/configurations/mouse_cerebellum_cortex.json
+++ b/bsb/configurations/mouse_cerebellum_cortex.json
@@ -338,10 +338,10 @@
       },
       "connection_models": {
         "glomerulus_to_granule": {
-          "synapses": ["AMPA", "NDMA"]
+          "synapses": ["AMPA", "NMDA"]
         },
         "glomerulus_to_golgi": {
-          "synapses": ["AMPA_MF","NDMA"]
+          "synapses": ["AMPA_MF","NMDA"]
         },
         "mossy_to_glomerulus": {
           "synapses": []
@@ -353,7 +353,7 @@
           "synapses": ["AMPA"]
         },
         "ascending_axon_to_golgi": {
-          "synapses": ["AMPA_AA","NDMA"]
+          "synapses": ["AMPA_AA","NMDA"]
         },
         "parallel_fiber_to_golgi": {
           "synapses": ["AMPA_PF"]

--- a/bsb/configurations/mouse_cerebellum_cortex.json
+++ b/bsb/configurations/mouse_cerebellum_cortex.json
@@ -338,49 +338,49 @@
       },
       "connection_models": {
         "glomerulus_to_granule": {
-          "synapse": "AMPA"
+          "synapses": ["AMPA", "NDMA"]
         },
         "glomerulus_to_golgi": {
-          "synapse": "AMPA_MF"
+          "synapses": ["AMPA_MF","NDMA"]
         },
         "mossy_to_glomerulus": {
-          "synapse": null
+          "synapses": null
         },
         "golgi_to_golgi": {
-          "synapse": "GABA"
+          "synapses": ["GABA"]
         },
         "ascending_axon_to_purkinje": {
-          "synapse": "AMPA"
+          "synapses": ["AMPA"]
         },
         "ascending_axon_to_golgi": {
-          "synapse": "AMPA_AA"
+          "synapses": ["AMPA_AA","NDMA"]
         },
         "parallel_fiber_to_golgi": {
-          "synapse": "AMPA_PF"
+          "synapses": ["AMPA_PF"]
         },
         "golgi_to_granule": {
-          "synapse": "GABA"
+          "synapses": ["GABA"]
         },
         "parallel_fiber_to_purkinje": {
-          "synapse": "AMPA"
+          "synapses": ["AMPA"]
         },
 	       "parallel_fiber_to_basket": {
-	          "synapse": "AMPA"
+	        "synapses":["AMPA", "NMDA"]
 	      },
         "parallel_fiber_to_stellate": {
-          "synapse": "AMPA"
+          "synapses": ["AMPA", "NMDA"]
         },
 	       "basket_to_purkinje": {
-	          "synapse": "GABA"
+	          "synapses": ["GABA"]
 	      },
         "stellate_to_purkinje": {
-          "synapse": "GABA"
+          "synapses": ["GABA"]
         },
         "stellate_to_stellate": {
-          "synapse": "GABA"
+          "synapses": ["GABA"]
         },
         "basket_to_basket": {
-          "synapse": "GABA"
+          "synapses": ["GABA"]
         }
       },
       "devices": {
@@ -419,7 +419,7 @@
           "device": "spike_generator",
           "targetting": "cell_type",
           "cell_types": ["mossy_fibers"],
-          "synapses": ["AMPA", "NMDA"],
+          "synapses": ["AMPA", "NMDA", "AMPA_MF"],
           "parameters": {
             "noise": true,
             "start": 100,
@@ -433,7 +433,7 @@
           "targetting": "by_id",
           "targets": [229, 213, 221, 228, 230, 220, 237, 203, 204, 205, 246, 212, 245],
           "cell_types": ["mossy_fibers"],
-          "synapses": ["AMPA", "NMDA"],
+          "synapses": ["AMPA", "NMDA", "AMPA_MF"],
           "parameters": {
             "noise": false,
             "start": 700,
@@ -447,7 +447,7 @@
           "targetting": "by_id",
           "targets": [229,213, 221, 228, 197, 270, 193, 273],
           "cell_types": ["mossy_fibers"],
-          "synapses": ["AMPA", "NMDA"],
+          "synapses": ["AMPA", "NMDA", "AMPA_MF"],
           "parameters": {
             "noise": true,
             "start": 100,

--- a/bsb/configurations/mouse_cerebellum_cortex.json
+++ b/bsb/configurations/mouse_cerebellum_cortex.json
@@ -344,7 +344,7 @@
           "synapses": ["AMPA_MF","NDMA"]
         },
         "mossy_to_glomerulus": {
-          "synapses": null
+          "synapses": []
         },
         "golgi_to_golgi": {
           "synapses": ["GABA"]

--- a/bsb/configurations/mouse_cerebellum_cortex.json
+++ b/bsb/configurations/mouse_cerebellum_cortex.json
@@ -3,7 +3,7 @@
   "output": {
     "format": "bsb.output.HDF5Formatter",
     "morphology_repository": "morphologies.hdf5",
-    "file": "300x_200z_130GrLThick.hdf5"
+    "file": "300x_200z.hdf5"
   },
   "network_architecture": {
     "simulation_volume_x": 300.0,
@@ -220,7 +220,7 @@
       "class": "bsb.connectivity.TouchDetector",
       "from_cell_types": [{"type": "granule_cell", "compartments": ["ascending_axon"]}],
       "to_cell_types": [{"type": "golgi_cell", "compartments": ["basal_dendrites"]}],
-      "compartment_intersection_radius": 2.0,
+      "compartment_intersection_radius": 3.0,
       "synapses": {
         "type": "norm",
         "loc": 5,
@@ -238,7 +238,7 @@
       "class": "bsb.connectivity.TouchDetector",
       "from_cell_types": [{"type": "granule_cell", "compartments": ["ascending_axon"]}],
       "to_cell_types": [{"type": "purkinje_cell", "compartments": ["aa_targets"]}],
-      "compartment_intersection_radius": 2.0,
+      "compartment_intersection_radius": 3.0,
       "synapses": {
         "type": "norm",
         "loc": 4,
@@ -388,7 +388,7 @@
           "io": "input",
           "device": "spike_generator",
           "targetting": "cell_type",
-          "cell_types": ["purkinje_cell", "golgi_cell", "basket_cell", "stellate_cell"],
+          "cell_types": ["golgi_cell", "basket_cell", "stellate_cell"],
           "section_type": "dendrites",
           "synapses": ["AMPA", "AMPA_PF"],
           "parameters": {
@@ -404,8 +404,8 @@
           "device": "spike_generator",
           "targetting": "cell_type",
           "cell_types": ["purkinje_cell"],
-          "section_type": "dendrites",
-          "synapses": ["AMPA", "AMPA_PF"],
+          "section_type": "aa_targets",
+          "synapses": ["AMPA"],
           "parameters": {
             "noise": true,
             "start": 100,

--- a/bsb/configurations/mouse_cerebellum_cortex.json
+++ b/bsb/configurations/mouse_cerebellum_cortex.json
@@ -196,7 +196,7 @@
       "class": "bsb.connectivity.ConnectomeGlomerulusGolgi",
       "from_cell_types": [{"type": "glomerulus", "compartments": ["soma"]}],
       "to_cell_types": [{"type": "golgi_cell", "compartments": ["basal_dendrites"]}],
-      "detailed": true,
+      "detailed": true
     },
     "golgi_to_granule": {
       "class": "bsb.connectivity.ConnectomeGolgiGranule",

--- a/bsb/configurations/mouse_cerebellum_cortex.json
+++ b/bsb/configurations/mouse_cerebellum_cortex.json
@@ -197,11 +197,6 @@
       "from_cell_types": [{"type": "glomerulus", "compartments": ["soma"]}],
       "to_cell_types": [{"type": "golgi_cell", "compartments": ["basal_dendrites"]}],
       "detailed": true,
-      "contacts": {
-        "type": "norm",
-        "loc": 20,
-        "scale": 4
-      }
     },
     "golgi_to_granule": {
       "class": "bsb.connectivity.ConnectomeGolgiGranule",

--- a/bsb/simulators/neuron/adapter.py
+++ b/bsb/simulators/neuron/adapter.py
@@ -67,13 +67,15 @@ class NeuronCell(SimulationCell):
 class NeuronConnection(SimulationComponent):
     node_name = "simulations.?.connection_models"
 
-    required = ["synapse"]
+    required = ["synapses"]
+
+    casts = {"synapses": list}
 
     def validate(self):
         pass
 
     def resolve_synapses(self):
-        return self.synapse if isinstance(self.synapse, list) else [self.synapse]
+        return self.synapses
 
 
 class NeuronDevice(TargetsNeurons, TargetsSections, SimulationComponent):
@@ -122,7 +124,7 @@ class NeuronDevice(TargetsNeurons, TargetsSections, SimulationComponent):
             + " device does not implement any `get_pattern` function."
         )
 
-    def implement(self, target, cell, section):
+    def implement(self, target, location):
         raise NotImplementedError(
             "The "
             + self.__class__.__name__
@@ -139,12 +141,12 @@ class NeuronDevice(TargetsNeurons, TargetsSections, SimulationComponent):
     def get_locations(self, target):
         locations = []
         if target in self.adapter.relay_scheme:
-            for cell_id, section_id in self.adapter.relay_scheme[target]:
+            for cell_id, section_id, connection in self.adapter.relay_scheme[target]:
                 if cell_id not in self.adapter.node_cells:
                     continue
                 cell = self.adapter.cells[cell_id]
                 section = cell.sections[section_id]
-                locations.append((cell, section))
+                locations.append(TargetLocation(cell, section, connection))
         elif target in self.adapter.node_cells:
             try:
                 cell = self.adapter.cells[target]
@@ -155,7 +157,7 @@ class NeuronDevice(TargetsNeurons, TargetsSections, SimulationComponent):
                     )
                 )
             sections = self.target_section(cell)
-            locations.extend((cell, section) for section in sections)
+            locations.extend(TargetLocation(cell, section) for section in sections)
         return locations
 
 
@@ -534,8 +536,8 @@ class NeuronAdapter(SimulatorAdapter):
             # Broadcast to make sure all the nodes have the same targets for each device.
             targets = self.scaffold.MPI.COMM_WORLD.bcast(targets, root=0)
             for target in targets:
-                for cell, section in device.get_locations(target):
-                    device.implement(target, cell, section)
+                for location in device.get_locations(target):
+                    device.implement(target, location)
 
     def index_relays(self):
         report("Indexing relays.")
@@ -573,7 +575,11 @@ class NeuronAdapter(SimulatorAdapter):
                 )
                 bin = terminal_relays
                 connections = connectivity_set.intersections
-                target = lambda c: (c.to_id, c.to_compartment.section_id)
+                target = lambda c: (
+                    c.to_id,
+                    c.to_compartment.section_id,
+                    connection_model,
+                )
             for id in self.scaffold.get_placement_set(from_cell_type.name).identifiers:
                 if id not in bin:
                     bin[id] = []
@@ -639,9 +645,9 @@ class NeuronAdapter(SimulatorAdapter):
         report(
             "Node",
             self.pc_id,
-            "needs to receive from",
+            "needs to relay",
             len(self.relay_scheme),
-            "relays",
+            "relays.",
             level=4,
         )
 
@@ -697,6 +703,16 @@ class LocationRecorder(SimulationRecorder):
 
     def get_meta(self):
         return self.meta
+
+
+class TargetLocation:
+    def __init__(self, cell, section, connection=None):
+        self.cell = cell
+        self.section = section
+        self.connection = connection
+
+    def get_synapses(self):
+        return self.connection and self.connection.synapses
 
 
 class SpikeRecorder(LocationRecorder):

--- a/bsb/simulators/neuron/devices/current_clamp.py
+++ b/bsb/simulators/neuron/devices/current_clamp.py
@@ -6,9 +6,9 @@ from ....reporting import report, warn
 
 
 class CurrentClamp(NeuronDevice):
-    def implement(self, target, cell, section):
-        pattern = self.get_pattern(target, cell, section)
-        section.iclamp(**pattern)
+    def implement(self, target, location):
+        pattern = self.get_pattern(target, location)
+        location.section.iclamp(**pattern)
 
     def validate_specifics(self):
         pass

--- a/bsb/simulators/neuron/devices/spike_generator.py
+++ b/bsb/simulators/neuron/devices/spike_generator.py
@@ -9,14 +9,16 @@ import numpy as np
 class SpikeGenerator(NeuronDevice):
     defaults = {"record": True}
 
-    def implement(self, target, cell, section):
+    def implement(self, target, location):
+        cell = location.cell
+        section = location.section
         if not hasattr(section, "available_synapse_types"):
             raise Exception(
                 "{} {} targetted by {} has no synapses".format(
                     cell.__class__.__name__, ",".join(section.labels), self.name
                 )
             )
-        for synapse_type in self.synapses:
+        for synapse_type in location.get_synapses() or self.synapses:
             if synapse_type in section.available_synapse_types:
                 synapse = cell.create_synapse(section, synapse_type)
                 pattern = self.get_pattern(target, cell, section, synapse_type)

--- a/bsb/simulators/neuron/devices/synapse_recorder.py
+++ b/bsb/simulators/neuron/devices/synapse_recorder.py
@@ -16,7 +16,9 @@ class SynapseRecorder(PatternlessDevice, NeuronDevice):
     def boot(self):
         pass
 
-    def implement(self, target, cell, section):
+    def implement(self, target, location):
+        cell = location.cell
+        section = location.section
         print(
             "Node",
             self.adapter.pc_id,

--- a/bsb/simulators/neuron/devices/synapse_recorder.py
+++ b/bsb/simulators/neuron/devices/synapse_recorder.py
@@ -10,7 +10,7 @@ class SynapseRecorder(PatternlessDevice, NeuronDevice):
     defaults = {
         "record_spikes": True,
         "record_current": False,
-        "type": None,
+        "types": None,
     }
 
     def boot(self):
@@ -33,7 +33,7 @@ class SynapseRecorder(PatternlessDevice, NeuronDevice):
         if self.record_current:
             print("Recording current...")
             recorder_classes.append(SynapticCurrentRecorder)
-        for synapse in get_section_synapses(section, self.type):
+        for synapse in get_section_synapses(section, self.types):
             for recorder_class in recorder_classes:
                 recorder = recorder_class(cell, section, synapse)
                 print(
@@ -67,9 +67,10 @@ class _SynapticRecorder(PresetPathMixin, PresetMetaMixin, SimulationRecorder):
         self.meta = {
             "cell": cell.ref_id,
             "section": cell.sections.index(section),
-            "x": point_process.get_loc(),
+            "x": point_process.get_segment().x,
             "type": synapse._type,
         }
+        p.pop_section()
         self.vectors = self._record(synapse._point_process)
 
     def get_data(self):

--- a/bsb/simulators/neuron/devices/voltage_recorder.py
+++ b/bsb/simulators/neuron/devices/voltage_recorder.py
@@ -5,7 +5,9 @@ import numpy as np
 class VoltageRecorder(NeuronDevice):
     casts = {"x": float}
 
-    def implement(self, target, cell, section):
+    def implement(self, target, location):
+        cell = location.cell
+        section = location.section
         group = "voltage_recorders"
         if hasattr(self, "group"):
             group = self.group

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ nrn-patch==3.0.0b0
 dbbs_models==1.3.0
 colour==0.1.5
 errr==1.0.0
+NEURON==7.8.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ plotly==4.1.0
 pre-commit==1.21.0
 black==20.8b1
 sphinx_rtd_theme==0.4.3
-nrn-patch==2.2.0
+nrn-patch==3.0.0b0
 dbbs_models==1.3.0
 colour==0.1.5
 errr==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
     },
     extras_require={
         "dev": ["sphinx", "sphinx_rtd_theme>=0.4.3", "pre-commit", "black==20.8b1"],
-        "NEURON": ["dbbs_models>=1.3.0", "nrn-patch>=2.2.0"],
+        "NEURON": ["dbbs_models>=1.3.1", "nrn-patch>=3.0.0b0"],
         "MPI": ["mpi4py"],
     },
 )


### PR DESCRIPTION
## Describe the work done

* `connection_model.synapse` is now `connection_model.synapses` and must be a list until v4 fixes this.
* Relay hopping respects the relay-target connection synapses.
* Adjusted configuration to reflect this and shuffled some targets around.

## List which issues this resolves:

closes #147, closes #148 
