### PR TITLE
Added fallback mechanism and failsafe warning to unbuffering of stdout

### DIFF
--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -12,7 +12,7 @@ def wrap_writer(stream, writer):
 
 try:
     sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), "wb", 0), write_through=True)
-except io.UnsupportedOperation:
+except io.UnsupportedOperation:  # pragma: nocover
     try:
         writers = ["write", "writelines"]
         for w in writers:

--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -14,8 +14,8 @@ try:
     sys.stdout = io.TextIOWrapper(open(sys.stdout.fileno(), "wb", 0), write_through=True)
 except io.UnsupportedOperation:
     try:
-        writes = ["write", "writelines"]
-        for w in writes:
+        writers = ["write", "writelines"]
+        for w in writers:
             writer = getattr(sys.stdout, w)
             wrapped = wrap_writer(sys.stdout, writer)
             setattr(sys.stdout, w, wrapped)


### PR DESCRIPTION
## Describe the work done

Added a fallback mechanism that wraps `write` and `writelines` of the stream to automatically flush afterwards. If that errors out a warning is raised that we could not unbuffer the output.

## List which issues this resolves:

closes #167 
