### PR TITLE
Added per branch colors to plot_morphology

### DIFF
--- a/bsb/plotting.py
+++ b/bsb/plotting.py
@@ -142,7 +142,7 @@ def _input_highlight(f, required=False):
             ]
             fig.update_layout(shapes=shapes)
         elif required:
-            raise ArgumentError("Required keyword argument `input_region` omitted.")
+            raise ArgumentError("Missing required keyword argument `input_region`.")
         return r
 
     return wrapper_function


### PR DESCRIPTION
## Describe the work done

You can now pass a dictionary as the `color` kwarg to `plot_morphology` and specify the `soma` and branch colors specifically. Any label that occurs in the morphology can be specified to color. Every branch needs to trigger at least 1 label or you'll get an error telling you which labels are not covered by your color dict. This can probably be improved by some catch all color parameter.

## List which issues this resolves:

@claudiacasellato Using your script you sent me as an example, you can now create colored basal & apical dendrites like this:

```python
colors = {
  "soma": "blue",
  "dendrites": "red",
  "axon": "blue"
}
plot_morphology(postM, offset=postPos, fig=fig, show=False, reduce_branches=False, soma_radius=postR,color=colors)
```
