### PR TITLE
Added synapse parameters in connect_params for devices

### DIFF
--- a/bsb/simulators/nest.py
+++ b/bsb/simulators/nest.py
@@ -816,6 +816,7 @@ class NestAdapter(SimulatorAdapter):
                     )
                 )
             connect_params.append(device_model.connection)
+            connect_params.append(device_model.synapse)
             # Send the Connect command to NEST and catch IllegalConnection errors.
             self.execute_command(
                 self.nest.Connect,


### PR DESCRIPTION
## Describe the work done
Added synapse parameters in connection parameters for devices. 

## List which issues this resolves:
needed when connecting NEST devices to real neurons (not parrots), where also NEST connection and synapse parameters should be specified in the configuration file.


