### PR TITLE
Updated plot_morphology ranges & aspect code

### DIFF
--- a/bsb/morphologies.py
+++ b/bsb/morphologies.py
@@ -362,17 +362,6 @@ class Morphology:
             return self.compartment_tree.get_arrays()[0]
         return [c.end for c in self.get_compartments(labels=labels)]
 
-    def get_plot_range(self, offset=[0.0, 0.0, 0.0]):
-        compartments = self.compartment_tree.get_arrays()[0]
-        n_dimensions = range(compartments.shape[1])
-        mins = np.array([np.min(compartments[:, i]) + offset[i] for i in n_dimensions])
-        max = np.max(
-            np.array(
-                [np.max(compartments[:, i]) - mins[i] + offset[i] for i in n_dimensions]
-            )
-        )
-        return list(zip(mins.tolist(), (mins + max).tolist()))
-
     def get_compartment_tree(self, labels=None):
         if labels is not None:
             return _compartment_tree(self.get_compartments(labels=labels))

--- a/bsb/plotting.py
+++ b/bsb/plotting.py
@@ -121,7 +121,14 @@ def _morpho_figure(f):
     @functools.wraps(f)
     @_figure
     def wrapper_function(
-        morphology, *args, offset=None, set_range=True, fig=None, swapaxes=True, **kwargs
+        morphology,
+        *args,
+        offset=None,
+        set_range=True,
+        fig=None,
+        swapaxes=True,
+        soma_radius=None,
+        **kwargs
     ):
         if offset is None:
             offset = [0.0, 0.0, 0.0]
@@ -132,10 +139,11 @@ def _morpho_figure(f):
             offset=offset,
             set_range=set_range,
             swapaxes=swapaxes,
+            soma_radius=soma_radius,
             **kwargs
         )
         if set_range:
-            rng = get_morphology_range(morphology, offset=offset)
+            rng = get_morphology_range(morphology, offset=offset, soma_radius=soma_radius)
             set_scene_range(fig.layout.scene, rng)
             set_scene_aspect(fig.layout.scene, rng)
         if swapaxes:
@@ -568,11 +576,12 @@ def set_morphology_scene_range(scene, offset_morphologies):
     set_scene_range(scene, combined_bounds)
 
 
-def get_morphology_range(morphology, offset=None):
+def get_morphology_range(morphology, offset=None, soma_radius=None):
     if offset is None:
         offset = [0.0, 0.0, 0.0]
+    r = soma_radius or 0.0
     itr = enumerate(morphology.flatten(vectors=["x", "y", "z"]))
-    r = [[min(v) + offset[i], max(v) + offset[i]] for i, v in itr]
+    r = [[min(min(v), -r) + offset[i], max(max(v), r) + offset[i]] for i, v in itr]
     return r
 
 

--- a/bsb/plotting.py
+++ b/bsb/plotting.py
@@ -110,6 +110,44 @@ def _network_figure(f):
     return wrapper_function
 
 
+def _morpho_figure(f):
+    """
+    Decorator for functions that produce a Figure of a morphology. Applies ``@_figure``
+    and can set the offset, range & aspectratio and can swap the Y & Z axis labels.
+
+    Adds the `offset`, `set_range` and `swapaxes` keyword arguments.
+    """
+
+    @functools.wraps(f)
+    @_figure
+    def wrapper_function(
+        morphology, *args, offset=None, set_range=True, fig=None, swapaxes=True, **kwargs
+    ):
+        if offset is None:
+            offset = [0.0, 0.0, 0.0]
+        r = f(
+            morphology,
+            *args,
+            fig=fig,
+            offset=offset,
+            set_range=set_range,
+            swapaxes=swapaxes,
+            **kwargs
+        )
+        if set_range:
+            rng = get_morphology_range(morphology)
+            set_scene_range(fig.layout.scene, rng)
+            set_scene_aspect(fig.layout.scene, rng)
+        if swapaxes:
+            axis_labels = dict(xaxis_title="X", yaxis_title="Z", zaxis_title="Y")
+        else:
+            axis_labels = dict(xaxis_title="X", yaxis_title="Y", zaxis_title="Z")
+        fig.update_layout(scene=axis_labels)
+        return r
+
+    return wrapper_function
+
+
 def _input_highlight(f, required=False):
     """
     Decorator for functions that highlight an input region on a Figure.
@@ -355,12 +393,11 @@ def plot_fiber_morphology(
     return fig
 
 
-@_network_figure
+@_morpho_figure
 def plot_morphology(
     morphology,
-    offset=[0.0, 0.0, 0.0],
+    offset=None,
     fig=None,
-    cubic=True,
     swapaxes=True,
     show=True,
     legend=True,
@@ -393,8 +430,6 @@ def plot_morphology(
     )
     for trace in traces:
         fig.add_trace(trace)
-    if set_range:
-        set_scene_range(fig.layout.scene, morphology.get_plot_range(offset=offset))
     return fig
 
 
@@ -507,6 +542,16 @@ def set_scene_range(scene, bounds):
     scene.zaxis.range = bounds[1]
 
 
+def set_scene_aspect(scene, bounds, mode="equal", swapaxes=True):
+    if mode == "equal":
+        ratios = np.array([d[1] - d[0] for d in bounds])
+        ratios = ratios / np.max(ratios)
+        items = zip(["x", "z", "y"] if swapaxes else ["x", "y", "z"], ratios)
+        scene.aspectratio = dict(items)
+    else:
+        scene.aspectmode = mode
+
+
 def set_morphology_scene_range(scene, offset_morphologies):
     """
     Set the range on a scene containing multiple morphologies.
@@ -514,13 +559,22 @@ def set_morphology_scene_range(scene, offset_morphologies):
     :param scene: A scene of the figure. If the figure itself is given, ``figure.layout.scene`` will be used.
     :param offset_morphologies: A list of tuples where the first element is offset and the 2nd is the :class:`Morphology`
     """
-    bounds = np.array(list(map(lambda m: m[1].get_plot_range(m[0]), offset_morphologies)))
+    bounds = np.array([get_morphology_range(m[1], m[0]) for m in offset_morphologies])
     combined_bounds = np.array(
         list(zip(np.min(bounds, axis=0)[:, 0], np.max(bounds, axis=0)[:, 1]))
     )
     span = max(map(lambda b: b[1] - b[0], combined_bounds))
     combined_bounds[:, 1] = combined_bounds[:, 0] + span
     set_scene_range(scene, combined_bounds)
+
+
+def get_morphology_range(morphology, offset=None):
+    if offset is None:
+        offset = [0.0, 0.0, 0.0]
+    itr = enumerate(morphology.flatten(vectors=["x", "y", "z"]))
+    r = [[min(v) + offset[i], max(v) + offset[i]] for i, v in itr]
+    print(r)
+    return r
 
 
 def hdf5_plot_spike_raster(spike_recorders, input_region=None, show=True):
@@ -846,5 +900,5 @@ class MorphologyScene:
         if len(self._morphologies) == 0:
             raise MorphologyError("Cannot show empty MorphologyScene")
         for o, m, k in self._morphologies:
-            plot_morphology(m, offset=o, show=False, fig=self.fig, **k)
+            plot_morphology(m, offset=o, show=False, set_range=False, fig=self.fig, **k)
         set_morphology_scene_range(self.fig.layout.scene, self._morphologies)

--- a/bsb/plotting.py
+++ b/bsb/plotting.py
@@ -135,7 +135,7 @@ def _morpho_figure(f):
             **kwargs
         )
         if set_range:
-            rng = get_morphology_range(morphology)
+            rng = get_morphology_range(morphology, offset=offset)
             set_scene_range(fig.layout.scene, rng)
             set_scene_aspect(fig.layout.scene, rng)
         if swapaxes:
@@ -573,7 +573,6 @@ def get_morphology_range(morphology, offset=None):
         offset = [0.0, 0.0, 0.0]
     itr = enumerate(morphology.flatten(vectors=["x", "y", "z"]))
     r = [[min(v) + offset[i], max(v) + offset[i]] for i, v in itr]
-    print(r)
     return r
 
 

--- a/tests/test_morphologies.py
+++ b/tests/test_morphologies.py
@@ -353,7 +353,6 @@ class TestLegacy(unittest.TestCase):
         m.get_compartment_network()
         m.get_compartment_positions()
         m.get_compartment_positions(labels=["A"])
-        m.get_plot_range()
         m.get_compartment_tree()
         m.get_compartment_tree(labels=["B"])
         m.get_compartment_submask(["C"])


### PR DESCRIPTION
`plot_morphology` used to create cubic figures as it was decorated with `_network_figure`, I've refactored that code into a `_morpho_figure` decorator that cuts off the empty space around a morphology and sets the appropriate range & aspect. I've also removed the plotting range code from the `Morphology` class and rewrote it with new SoA code in `plotting.py`