### PR TITLE
Import NEST before mpi4py.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # 3.7
 
+## 3.7.1
+
+* Fixed a bug with nest and MPI. (see #230)
+
 ## 3.7.0
 
 * The NEURON adapter now supports source variables.

--- a/bsb/__init__.py
+++ b/bsb/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "3.7.0"
+__version__ = "3.7.1"
 
 from .reporting import set_verbosity, report, warn

--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -111,6 +111,10 @@ def _encode(header, message):
 # any scaffold is created.
 
 try:
+    try:
+        import nest
+    except:
+        pass
     from mpi4py import MPI as _MPI
 
     MPI_rank = _MPI.COMM_WORLD.rank


### PR DESCRIPTION
## Describe the work done

Import nest before mpi4py. Otherwise confusing failures or segmentation faults occur, 

## List which issues this resolves:

closes #230 