### PR TITLE
Allow creating devices without any target

### DIFF
--- a/bsb/simulation/targetting.py
+++ b/bsb/simulation/targetting.py
@@ -104,8 +104,13 @@ class TargetsNeurons:
         n = len(ids)
         # Use the `cell_fraction` or `cell_count` attribute to determine what portion of
         # the selected ids to exclude.
-        r_threshold = getattr(self, "cell_fraction", getattr(self, "cell_count", n) / n)
-        ids = ids[np.random.random_sample(n) <= r_threshold]
+        if n != 0:
+            r_threshold = getattr(
+                self, "cell_fraction", getattr(self, "cell_count", n) / n
+            )
+            ids = ids[np.random.random_sample(n) <= r_threshold]
+        else:
+            ids = []
         return ids
 
     def _targets_representatives(self):

--- a/bsb/simulation/targetting.py
+++ b/bsb/simulation/targetting.py
@@ -108,10 +108,14 @@ class TargetsNeurons:
             r_threshold = getattr(
                 self, "cell_fraction", getattr(self, "cell_count", n) / n
             )
-            ids = ids[np.random.random_sample(n) <= r_threshold]
+            if r_threshold == 1:
+                return ids
+            elif r_threshold == 0:
+                return np.empty(0)
+            else:
+                return ids[np.random.riandom_sample(n) <= r_threshold]
         else:
-            ids = []
-        return ids
+            return np.empty(0)
 
     def _targets_representatives(self):
         target_types = [


### PR DESCRIPTION
## Describe the work done
It allows to create devices without necessarily defining target cell types. 
## List which issues this resolves:
Fix #237 