### PR TITLE
Optimized golgi to granule

### DIFF
--- a/bsb/connectivity/connectome/golgi_granule.py
+++ b/bsb/connectivity/connectome/golgi_granule.py
@@ -29,9 +29,6 @@ class ConnectomeGolgiGranule(ConnectionStrategy):
             self.morphology = morphology
 
     def connect(self):
-        from time import time
-
-        t = time()
         # Gather information for the legacy code block below.
         glom_grc = self.scaffold.cell_connections_by_tag["glomerulus_to_granule"]
         glom_ids = self.scaffold.get_placement_set("glomerulus").identifiers

--- a/bsb/connectivity/connectome/golgi_granule.py
+++ b/bsb/connectivity/connectome/golgi_granule.py
@@ -29,8 +29,12 @@ class ConnectomeGolgiGranule(ConnectionStrategy):
             self.morphology = morphology
 
     def connect(self):
+        from time import time
+
+        t = time()
         # Gather information for the legacy code block below.
         glom_grc = self.scaffold.cell_connections_by_tag["glomerulus_to_granule"]
+        glom_ids = self.scaffold.get_placement_set("glomerulus").identifiers
         goc_glom = self.scaffold.cell_connections_by_tag["golgi_to_glomerulus"]
         golgi_type = self.from_cell_types[0]
         golgis = self.scaffold.cells_by_type[golgi_type.name]
@@ -44,70 +48,69 @@ class ConnectomeGolgiGranule(ConnectionStrategy):
                 raise RuntimeError(
                     "Missing the glomerulus to granule connection compartments."
                 )
-        compartments = np.empty((0, 2))
+        # Index the glom to granule dense matrix to an adjacency list
+        glom_target_map = {gid: [] for gid in glom_ids}
+        for glom, grc in glom_grc:
+            glom_target_map[glom].append(grc)
 
-        def connectome_goc_grc(golgis, glom_grc, goc_glom):
-            # Connect all golgi cells to the granule cells that they share a glomerulus with.
-            glom_grc_per_glom = {}
-            goc_grc = np.empty((0, 2))
-            golgi_ids = golgis[:, 0]
-            for golgi_id in golgis[:, 0]:
-                # Fetch all the glomeruli this golgi is connected to
-                connected_glomeruli = goc_glom[goc_glom[:, 0] == golgi_id, 1]
-                # Find all the glomerulus-granule connections involving the glomeruli this golgi is connected to.
-                intermediary_indices = [
-                    i for i, row in enumerate(glom_grc) if row[0] in connected_glomeruli
-                ]
-                intermediary_connections = glom_grc[intermediary_indices]
-                # Extract the ids of the granule cells from these connections
-                target_granules = [row[1] for row in intermediary_connections]
-                goc_grc = np.vstack(
-                    (
-                        goc_grc,
-                        # Create a matrix with 2 columns where the 1st column is the golgi id
-                        np.column_stack(
-                            (
-                                golgi_id * np.ones(len(target_granules)),
-                                # and the 2nd column is all granules connected to one of the glomeruli the golgi is connected to.
-                                target_granules,
-                            )
-                        ),
-                    )
-                )
-                if self.detailed:
-                    nonlocal compartments
-                    compartments = np.vstack(
-                        (
-                            compartments,
-                            np.column_stack(
-                                (
-                                    self.axon[
-                                        np.random.randint(
-                                            0, len(self.axon), len(target_granules)
-                                        )
-                                    ],
-                                    glom_grc_compartments[intermediary_indices, 1] - 1,
-                                )
-                            ),
-                        )
-                    )
-
-            return goc_grc
-
-        result = connectome_goc_grc(golgis, glom_grc, goc_glom)
         if self.detailed:
+            # Lookup the grc compartments associated with each glom-grc conn
+            glom_comp_map = {gid: [] for gid in glom_ids}
+            for i, glom in enumerate(glom_grc[:, 0]):
+                glom_comp_map[glom].append(glom_grc_compartments[i, 1])
+
+        # Lookup the grc targets of each golgi-glom in the order they appear.
+        grc_via_glom = np.vectorize(glom_target_map.get, otypes=[np.ndarray])(
+            goc_glom[:, 1]
+        )
+
+        if self.detailed:
+            comp_via_glom = np.vectorize(glom_comp_map.get, otypes=[np.ndarray])(
+                goc_glom[:, 1]
+            )
+
+        # Sum the targets to preallocate total size
+        malloc = sum(map(len, grc_via_glom))
+        connections = np.empty((malloc, 2))
+        ptr = 0
+        # Iterate over the golgis and their grc targets (as lookup up in order
+        # via the gloms) and fill them into the connections array
+        for goc, grcs in zip(goc_glom[:, 0], grc_via_glom):
+            s = len(grcs)
+            if not s:
+                # Skip any weird slicing of empty target sets
+                continue
+            connections[ptr : (ptr + s), 0] = goc
+            connections[ptr : (ptr + s), 1] = grcs
+            ptr += s
+
+        if self.detailed:
+            compartments = np.empty((malloc, 2))
+            # Assign random axonal segments
+            compartments[:, 0] = np.random.choice(self.axon, malloc)
+            ptr = 0
+            # Assign the glom associated dendrites
+            for comps in comp_via_glom:
+                s = len(comps)
+                if not s:
+                    # Skip any weird slicing of empty target sets
+                    continue
+                compartments[ptr : (ptr + s), 1] = comps
+                ptr += s
+            # Make a bad map ignoring all but the first (only) morphologies
+            # of each type. Sorry future me <3
             morpho_map = [
                 self.from_cell_types[0].list_all_morphologies()[0],
                 self.to_cell_types[0].list_all_morphologies()[0],
             ]
-            morphologies = np.zeros((len(result), 2))
-            morphologies[:, 1] += 1
+            morphologies = np.zeros((len(compartments), 2))
+            morphologies[:, 1] = 1
             self.scaffold.connect_cells(
                 self,
-                result,
+                connections,
                 morphologies=morphologies,
                 compartments=compartments,
                 morpho_map=morpho_map,
             )
         else:
-            self.scaffold.connect_cells(self, result)
+            self.scaffold.connect_cells(self, connections)


### PR DESCRIPTION
Dropped runtime from days down to 1 minute, there was a lot of `vstacking` and `O(n^2)` linear searching going on; replaced with vectorized hashmap lookups and made better use of the ordered columns of the connectivity matrices.