### PR TITLE
Use dynamic catalogues

### DIFF
--- a/bsb/simulators/arbor/adapter.py
+++ b/bsb/simulators/arbor/adapter.py
@@ -36,7 +36,7 @@ class ArborCell(SimulationCell):
         if not self.relay:
             return self.model_class.cable_cell()
         else:
-            return arbor.spike_source_cell(arbor.explicit_schedule([]))
+            return arbor.spike_source_cell(self.name, arbor.explicit_schedule([]))
 
 
 class ArborDevice(SimulationCell):
@@ -93,7 +93,8 @@ class ArborRecipe(arbor.recipe):
         super().__init__()
         self._adapter = adapter
         self._catalogue = arbor.default_catalogue()
-        self._catalogue.extend(arbor.dbbs_catalogue(), "")
+        self._dbbs_catalogue = arbor.load_catalogue("dbbs-catalogue.so")
+        self._catalogue.extend(self._dbbs_catalogue, "")
         self._global_properties = arbor.neuron_cable_properties()
         self._global_properties.set_property(Vm=-65, tempK=300, rL=35.4, cm=0.01)
         self._global_properties.set_ion(ion="na", int_con=10, ext_con=140, rev_pot=50)


### PR DESCRIPTION
Hi,

as per private comms w/ @Helveg I made a branch off of branch `3.8` for modern (post-MechABI) arbor.
Changes are minimal, but remove the requirement of forking, extending, building, and installing arbor for 
the dbbs catalogue. Workflow now would be:

- install arbor from master (⚠️ wait until https://github.com/arbor-sim/arbor/pull/1657 is resolved, or use it preliminarily)
- copy all .mod you need into a directory, eg `dbbs` (⚠️ not all of the mechs in the dbbs fork are valid)
- call `build-catalogue dbbs dbbs/` in bash; this gives you a shared object `dbbs-catalogue.so`
- in the directory with the catalogue start `bsb`

Some open points: 
- I do not know how you pass configurations down to simulators, so I chose `./dbbs-catalogue.so`. Should be improved.
- Similarly, no idea how you do logging, but it would be *great* to know if `arbor` has been replaced by a shim on ImportError.