### PR TITLE
NEST weights set as distribution - error

### DIFF
--- a/bsb/simulators/nest.py
+++ b/bsb/simulators/nest.py
@@ -157,7 +157,11 @@ class NestConnection(SimulationComponent):
         # Add the receptor specifications, if required.
         if self.should_specify_receptor_type():
             # If specific receptors are specified, the weight should always be positive.
-            params["weight"] = np.abs(params["weight"])
+            if type(params["weight"]) is dict:
+                if "mu" in params["weight"].keys():
+                    params["weight"]["mu"] = np.abs(params["weight"]["mu"])
+            else:
+                params["weight"] = np.abs(params["weight"])
             if "Wmax" in params:
                 params["Wmax"] = np.abs(params["Wmax"])
             if "Wmin" in params:

--- a/bsb/simulators/nest.py
+++ b/bsb/simulators/nest.py
@@ -157,6 +157,8 @@ class NestConnection(SimulationComponent):
         # Add the receptor specifications, if required.
         if self.should_specify_receptor_type():
             # If specific receptors are specified, the weight should always be positive.
+            # We try to sanitize user data as best we can. If the given weight is a distr
+            # (given as a dict) we try to sanitize the `mu` value, if present.
             if type(params["weight"]) is dict:
                 if "mu" in params["weight"].keys():
                     params["weight"]["mu"] = np.abs(params["weight"]["mu"])


### PR DESCRIPTION
If NEST weights are set as distribution, access to them when setting their value to absolute would give an error.
