### PR TITLE
IOError due to growing device label

### DIFF
--- a/bsb/simulators/nest.py
+++ b/bsb/simulators/nest.py
@@ -1033,7 +1033,7 @@ class SpikeDetectorProtocol(DeviceProtocol):
             )
         device_tag = str(_randint())
         device_tag = mpi4py.MPI.COMM_WORLD.bcast(device_tag, root=0)
-        if not hasattr(self.device._orig_label):
+        if not hasattr(self.device, "_orig_label"):
             self.device._orig_label = self.device.parameters["label"]
         self.device.parameters["label"] = self.device._orig_label + device_tag
         if mpi4py.MPI.COMM_WORLD.rank == 0:

--- a/bsb/simulators/nest.py
+++ b/bsb/simulators/nest.py
@@ -1034,7 +1034,7 @@ class SpikeDetectorProtocol(DeviceProtocol):
         device_tag = str(_randint())
         device_tag = mpi4py.MPI.COMM_WORLD.bcast(device_tag, root=0)
         if not hasattr(self.device._orig_label):
-            setattr(self.device._orig_label) = self.device.parameters["label"]
+            self.device._orig_label = self.device.parameters["label"]
         self.device.parameters["label"] = self.device._orig_label + device_tag
         if mpi4py.MPI.COMM_WORLD.rank == 0:
             self.device.adapter.result.add(SpikeRecorder(self.device))

--- a/bsb/simulators/nest.py
+++ b/bsb/simulators/nest.py
@@ -1033,7 +1033,9 @@ class SpikeDetectorProtocol(DeviceProtocol):
             )
         device_tag = str(_randint())
         device_tag = mpi4py.MPI.COMM_WORLD.bcast(device_tag, root=0)
-        self.device.parameters["label"] += device_tag
+        if not hasattr(self.device._orig_label):
+            setattr(self.device._orig_label) = self.device.parameters["label"]
+        self.device.parameters["label"] = self.device._orig_label + device_tag
         if mpi4py.MPI.COMM_WORLD.rank == 0:
             self.device.adapter.result.add(SpikeRecorder(self.device))
 


### PR DESCRIPTION
## Describe the work done

Prevent ever growing device label and NEST IO-error when looping simulations. If an adapter is reused in the following idion:

```python
for x in range(50):
  adapter.reset()
  adapter.prepare()
  # ...
```

then each loop the device labels are appended a random string, resulting in ever growing `.gdf` file names until they are too long for the filesystem to handle and NEST throws an `IOError`. I fixed it by keeping the original label around and each loop appending a single random suffix.

## List which issues this resolves:

closes #291 
