### PR TITLE
Raise `UnknownGIDError` if unknown GIDs occur in connectivity sets.

### DIFF
--- a/bsb/exceptions.py
+++ b/bsb/exceptions.py
@@ -38,7 +38,9 @@ _t(
             ),
             ParallelIntegrityError=_e("rank"),
         ),
-        ConnectivityError=_e(),
+        ConnectivityError=_e(
+            UnknownGIDError=_e(),
+        ),
         MorphologyError=_e(
             MorphologyRepositoryError=_e(),
             MissingMorphologyError=_e(),

--- a/bsb/simulators/nest.py
+++ b/bsb/simulators/nest.py
@@ -709,12 +709,22 @@ class NestAdapter(SimulatorAdapter):
                 )
                 continue
             # Get the NEST identifiers for the connections made in the connectivity matrix
-            presynaptic_sources = np.array(
-                self.get_nest_ids(np.array(cs.from_identifiers, dtype=int))
-            )
-            postsynaptic_targets = np.array(
-                self.get_nest_ids(np.array(cs.to_identifiers, dtype=int))
-            )
+            try:
+                presynaptic_sources = np.array(
+                    self.get_nest_ids(np.array(cs.from_identifiers, dtype=int))
+                )
+            except KeyError as e:
+                raise UnknownGIDError(
+                    f"Unknown GID {e.args[0]} in presynaptic `{name}` data."
+                ) from None
+            try:
+                postsynaptic_targets = np.array(
+                    self.get_nest_ids(np.array(cs.to_identifiers, dtype=int))
+                )
+            except KeyError as e:
+                raise UnknownGIDError(
+                    f"Unknown GID {e.args[0]} in postsynaptic `{name}` data."
+                ) from None
             if not len(presynaptic_sources) or not len(postsynaptic_targets):
                 warn("No connections for " + name)
                 continue
@@ -856,7 +866,7 @@ class NestAdapter(SimulatorAdapter):
                             device_model.get_config_node()
                         ),
                     }
-                }
+                },
             )
 
     def create_model(self, cell_model):


### PR DESCRIPTION
## Describe the work done

When there's problems in translating connectivity scaffold IDs to NEST IDs a `UnknownGIDError` is thrown with some information to help users figure out the problem

## List which issues this resolves:

closes #287 