### PR TITLE
Don't warn on proper module loading between resets

### DIFF
--- a/bsb/simulators/nest.py
+++ b/bsb/simulators/nest.py
@@ -775,8 +775,9 @@ class NestAdapter(SimulatorAdapter):
             report("Creating connections " + nest_name, level=3)
             # Create the connections in NEST
             if not (connection_model.plastic and connection_model.hetero):
+                receptor_cfg = connection_parameters.get("receptor_type", [])
                 # Repeat connections per receptor type
-                receptor_types = listify_input(connection_parameters["receptor_type"])
+                receptor_types = listify_input(receptor_cfg)
                 if not len(receptor_types):
                     # If no receptor types are specified, go over the connection loop
                     # once, without setting any receptor type in the conn params.


### PR DESCRIPTION
## Describe the work done

The adapter warned about loading modules during repeated simulations because `ResetKernel` does not unload modules, and `install_modules` is an integral part of `prepare`, so `reset`/`prepare` cycles unjustly warned about reloading all the config specified modules.

## List which issues this resolves:

closes #294 
