### PR TITLE
Filtered PlacementSets

### DIFF
--- a/bsb/connectivity/detailed/fiber_intersection.py
+++ b/bsb/connectivity/detailed/fiber_intersection.py
@@ -67,8 +67,12 @@ class FiberIntersection(ConnectionStrategy, MorphologyStrategy):
         from_compartments = self.from_cell_compartments[0]
         to_compartments = self.to_cell_compartments[0]
         to_type = self.to_cell_types[0]
-        from_placement_set = self.scaffold.get_placement_set(from_type.name, labels=[self.label_pre])
-        to_placement_set = self.scaffold.get_placement_set(to_type.name, labels=[self.label_post])
+        from_placement_set = self.scaffold.get_placement_set(
+            from_type.name, labels=[self.label_pre]
+        )
+        to_placement_set = self.scaffold.get_placement_set(
+            to_type.name, labels=[self.label_post]
+        )
 
         # Load the morphology and voxelization data for the entrire morphology, for each cell type.
         from_morphology_set = MorphologySet(

--- a/bsb/connectivity/detailed/fiber_intersection.py
+++ b/bsb/connectivity/detailed/fiber_intersection.py
@@ -67,8 +67,8 @@ class FiberIntersection(ConnectionStrategy, MorphologyStrategy):
         from_compartments = self.from_cell_compartments[0]
         to_compartments = self.to_cell_compartments[0]
         to_type = self.to_cell_types[0]
-        from_placement_set = self.scaffold.get_placement_set(from_type.name)
-        to_placement_set = self.scaffold.get_placement_set(to_type.name)
+        from_placement_set = self.scaffold.get_placement_set(from_type.name, labels=[self.label_pre])
+        to_placement_set = self.scaffold.get_placement_set(to_type.name, labels=[self.label_post])
 
         # Load the morphology and voxelization data for the entrire morphology, for each cell type.
         from_morphology_set = MorphologySet(

--- a/bsb/connectivity/detailed/touch_detection.py
+++ b/bsb/connectivity/detailed/touch_detection.py
@@ -139,12 +139,12 @@ class TouchDetector(ConnectionStrategy, MorphologyStrategy):
         touching_cells = 0
         for i in range(len(candidate_map)):
             if i % 100 == 0:
-                percentage = 100*float(i)/float(len(candidate_map))            
+                percentage = 100 * float(i) / float(len(candidate_map))
                 report(
-                f"Connection progress: {percentage:.2f}%...",
-                level=2,
+                    f"Connection progress: {percentage:.2f}%...",
+                    level=2,
+                    ongoing=True,
                 )
-                counter = 0            
             from_id = touch_info.from_identifiers[i]
             touch_info.from_morphology = self.get_random_morphology(
                 touch_info.from_cell_type

--- a/bsb/connectivity/detailed/touch_detection.py
+++ b/bsb/connectivity/detailed/touch_detection.py
@@ -76,11 +76,11 @@ class TouchDetector(ConnectionStrategy, MorphologyStrategy):
                     to_cell_compartments,
                 )
                 touch_info.from_placement = self.scaffold.get_placement_set(
-                    from_cell_type
+                    from_cell_type, labels=[self.label_pre]
                 )
                 touch_info.from_positions = list(touch_info.from_placement.positions)
                 touch_info.from_identifiers = list(touch_info.from_placement.identifiers)
-                touch_info.to_placement = self.scaffold.get_placement_set(to_cell_type)
+                touch_info.to_placement = self.scaffold.get_placement_set(to_cell_type, labels=[self.label_post])
                 touch_info.to_identifiers = list(touch_info.to_placement.identifiers)
                 touch_info.to_positions = list(touch_info.to_placement.positions)
                 # Intersect cells on the widest possible search radius.

--- a/bsb/connectivity/detailed/touch_detection.py
+++ b/bsb/connectivity/detailed/touch_detection.py
@@ -80,7 +80,9 @@ class TouchDetector(ConnectionStrategy, MorphologyStrategy):
                 )
                 touch_info.from_positions = list(touch_info.from_placement.positions)
                 touch_info.from_identifiers = list(touch_info.from_placement.identifiers)
-                touch_info.to_placement = self.scaffold.get_placement_set(to_cell_type, labels=[self.label_post])
+                touch_info.to_placement = self.scaffold.get_placement_set(
+                    to_cell_type, labels=[self.label_post]
+                )
                 touch_info.to_identifiers = list(touch_info.to_placement.identifiers)
                 touch_info.to_positions = list(touch_info.to_placement.positions)
                 # Intersect cells on the widest possible search radius.

--- a/bsb/connectivity/detailed/voxel_intersection.py
+++ b/bsb/connectivity/detailed/voxel_intersection.py
@@ -49,8 +49,8 @@ class VoxelIntersection(ConnectionStrategy, MorphologyStrategy):
         from_compartments = self.from_cell_compartments[0]
         to_compartments = self.to_cell_compartments[0]
         to_type = self.to_cell_types[0]
-        from_placement_set = self.scaffold.get_placement_set(from_type.name)
-        to_placement_set = self.scaffold.get_placement_set(to_type.name)
+        from_placement_set = self.scaffold.get_placement_set(from_type.name, labels=[self.label_pre])
+        to_placement_set = self.scaffold.get_placement_set(to_type.name, labels=[self.label_post])
         from_cells = self.scaffold.get_cells_by_type(from_type.name)
         to_cells = self.scaffold.get_cells_by_type(to_type.name)
 

--- a/bsb/connectivity/detailed/voxel_intersection.py
+++ b/bsb/connectivity/detailed/voxel_intersection.py
@@ -49,8 +49,12 @@ class VoxelIntersection(ConnectionStrategy, MorphologyStrategy):
         from_compartments = self.from_cell_compartments[0]
         to_compartments = self.to_cell_compartments[0]
         to_type = self.to_cell_types[0]
-        from_placement_set = self.scaffold.get_placement_set(from_type.name, labels=[self.label_pre])
-        to_placement_set = self.scaffold.get_placement_set(to_type.name, labels=[self.label_post])
+        from_placement_set = self.scaffold.get_placement_set(
+            from_type.name, labels=[self.label_pre]
+        )
+        to_placement_set = self.scaffold.get_placement_set(
+            to_type.name, labels=[self.label_post]
+        )
         from_cells = self.scaffold.get_cells_by_type(from_type.name)
         to_cells = self.scaffold.get_cells_by_type(to_type.name)
 

--- a/bsb/core.py
+++ b/bsb/core.py
@@ -773,7 +773,7 @@ class Scaffold:
         """
         return self.output_formatter.get_connectivity_set(tag)
 
-    def get_placement_set(self, type):
+    def get_placement_set(self, type, labels=None):
         """
         Return a cell type's placement set from the output formatter.
 
@@ -784,7 +784,14 @@ class Scaffold:
         """
         if isinstance(type, str):
             type = self.get_cell_type(type)
-        return self.output_formatter.get_placement_set(type)
+        ps = self.output_formatter.get_placement_set(type)
+        if labels is not None:
+
+            def label_filter():
+                return np.concatenate(tuple(self.get_labelled_ids(l) for l in labels))
+
+            ps.set_filter(label_filter)
+        return ps
 
     def translate_cell_ids(self, data, cell_type):
         """
@@ -998,7 +1005,11 @@ class Scaffold:
         """
         Get all the global identifiers of cells labelled with the specific label.
         """
-        return np.array(self.labels[label], dtype=int)
+        try:
+            data = self.labels[label]
+        except KeyError:
+            data = []
+        return np.array(data, dtype=int)
 
     def get_cell_total(self):
         """

--- a/bsb/models.py
+++ b/bsb/models.py
@@ -474,12 +474,12 @@ class PlacementSet(Resource):
         identifier_resource = Resource(handler, root + tag + "/identifiers")
         self._filter = f = _Filter()
 
-        def filter_by_ids():
+        def id_source():
             return np.array(
                 expand_continuity_list(identifier_resource.get_dataset()), dtype=int
             )
 
-        self._filter.filter_by = filter_by_ids
+        self._filter.filter_source = id_source
         self.identifier_set = _FilteredIds(handler, root + tag + "/identifiers", f)
         self.positions_set = _FilteredResource(handler, root + tag + "/positions", f)
         self.rotation_set = _FilteredResource(handler, root + tag + "/rotations", f)
@@ -552,13 +552,22 @@ class PlacementSet(Resource):
 
 
 class _Filter:
+    """
+    To use, set an `active_filter` and `filter_source` function that return numpy arrays.
+
+    `filter_source` should return a dataset of the same shape as the `data` being filtered.
+    `active_filter` will then be called to create a boolean mask from `filter_source`,
+    applied as a filter on the data being filtered. (This means that `filter_source` and
+    `data` should be parallel arrays)
+    """
+
     active_filter = None
-    filter_by = None
+    filter_source = None
 
     def filter(self, data):
         if self.active_filter is None:
             return data
-        return data[np.isin(self.filter_by(), self.active_filter())]
+        return data[np.isin(self.filter_source(), self.active_filter())]
 
 
 class _FilteredResource(Resource):


### PR DESCRIPTION
## Describe the work done

Added a mechanism for `PlacementSet`s to dynamically filter themselves based on an identifier filter. Using `set_filter(f)` one can pass a function that needs to return the filtered identifiers. This list of IDs will then be used to filter all parallel arrays of the placement set (identifiers, rotations, ...)

## List which issues this resolves:

Adresses an issue @tiziana-t faces with labelled connections and the `PlacementSet` API. Since there's a major design issue in v3 with the cache, usage of the PlacementSet API is recommended, but that was insensitive to the labels that connection types were using. Now one can filter the PlacementSet properties with the labels that `.connect` is called with:

```python
def connect(self):
  ps_from = self.scaffold.get_placement_set(self.from_cell_types[0], labels=[self.label_pre])
  ps_to = self.scaffold.get_placement_set(self.to_cell_types[0], labels=[self.label_post])
```

## Tasks

@tiziana-t can you test whether this works for you?