### PR TITLE
Deal with empty compartment sets in `TouchDetector`

### DIFF
--- a/bsb/connectivity/detailed/touch_detection.py
+++ b/bsb/connectivity/detailed/touch_detection.py
@@ -211,7 +211,7 @@ class TouchDetector(ConnectionStrategy, MorphologyStrategy):
         to_morpho = touch_info.to_morphology
         to_comps = to_morpho.get_compartment_positions(touch_info.to_cell_compartments)
         from_tree = from_morpho.get_compartment_tree(touch_info.from_cell_compartments)
-        if from_tree is None or not to_comps:
+        if from_tree is None or not len(to_comps):
             return []
         query_points = to_comps + to_pos - from_pos
         compartment_hits = from_tree.query_radius(

--- a/bsb/connectivity/detailed/touch_detection.py
+++ b/bsb/connectivity/detailed/touch_detection.py
@@ -63,7 +63,6 @@ class TouchDetector(ConnectionStrategy, MorphologyStrategy):
     def connect(self):
         labels_pre = None if self.label_pre is None else [self.label_pre]
         labels_post = None if self.label_post is None else [self.label_post]
-        # Create a dictionary to cache loaded morphologies.
         self.morphology_cache = {}
         for from_cell_type_index in range(len(self.from_cell_types)):
             from_cell_type = self.from_cell_types[from_cell_type_index]
@@ -210,12 +209,11 @@ class TouchDetector(ConnectionStrategy, MorphologyStrategy):
     def get_compartment_intersections(self, touch_info, from_pos, to_pos):
         from_morpho = touch_info.from_morphology
         to_morpho = touch_info.to_morphology
-        query_points = (
-            to_morpho.get_compartment_positions(touch_info.to_cell_compartments)
-            + to_pos
-            - from_pos
-        )
+        to_comps = to_morpho.get_compartment_positions(touch_info.to_cell_compartments)
         from_tree = from_morpho.get_compartment_tree(touch_info.from_cell_compartments)
+        if from_tree is None or not to_comps:
+            return []
+        query_points = to_comps + to_pos - from_pos
         compartment_hits = from_tree.query_radius(
             query_points, self.compartment_intersection_radius
         )

--- a/bsb/core.py
+++ b/bsb/core.py
@@ -1170,6 +1170,13 @@ def merge(output_file, *others, label_prefix="merged_"):
     return merged
 
 
+def get_mrepo(file):
+    """
+    Shortcut function to create :class:`.output.MorphologyRepository`
+    """
+    return MorphologyRepository(file)
+
+
 class ReportListener:
     def __init__(self, scaffold, file):
         self.file = file

--- a/bsb/morphologies.py
+++ b/bsb/morphologies.py
@@ -465,7 +465,7 @@ class Morphology:
 def _compartment_tree(compartments):
     comp_matrix = np.array([c.end for c in compartments])
     if not len(comp_matrix):
-        comp_matrix = comp_matrix.reshape(-1, 3)
+        comp_matrix = np.array([[float("nan"), float("nan"), float("nan")]])
     return KDTree(comp_matrix)
 
 

--- a/bsb/morphologies.py
+++ b/bsb/morphologies.py
@@ -463,7 +463,10 @@ class Morphology:
 
 
 def _compartment_tree(compartments):
-    return KDTree(np.array([c.end for c in compartments]))
+    comp_matrix = np.array([c.end for c in compartments])
+    if not len(comp_matrix):
+        comp_matrix = comp_matrix.reshape(-1, 3)
+    return KDTree(comp_matrix)
 
 
 class Representation(ConfigurableClass):

--- a/bsb/morphologies.py
+++ b/bsb/morphologies.py
@@ -426,14 +426,18 @@ class Morphology:
         return node_list
 
     def get_compartment_positions(self, labels=None):
-        if labels is None:
-            return self.compartment_tree.get_arrays()[0]
-        return [c.end for c in self.get_compartments(labels=labels)]
+        comp_pos = [c.end for c in self.get_compartments(labels=labels)]
+        return np.array(comp_pos).reshape(-1, 3)
 
     def get_compartment_tree(self, labels=None):
-        if labels is not None:
-            return _compartment_tree(self.get_compartments(labels=labels))
-        return self.compartment_tree
+        if labels is None:
+            return self.compartment_tree
+        else:
+            labelled_comps = self.get_compartments(labels=labels)
+            if labelled_comps:
+                return _compartment_tree(labelled_comps)
+            else:
+                return None
 
     def get_compartment_submask(self, labels):
         ## TODO: Remove; voxelintersection & touchdetection audit should make this code
@@ -463,10 +467,11 @@ class Morphology:
 
 
 def _compartment_tree(compartments):
-    comp_matrix = np.array([c.end for c in compartments])
-    if not len(comp_matrix):
-        comp_matrix = np.array([[float("nan"), float("nan"), float("nan")]])
-    return KDTree(comp_matrix)
+    return KDTree(np.array([c.end for c in compartments]))
+
+
+class EmptyTree:
+    pass
 
 
 class Representation(ConfigurableClass):

--- a/bsb/particles.py
+++ b/bsb/particles.py
@@ -191,7 +191,8 @@ class ParticleSystem:
                 if self.track_displaced:
                     self.displaced_particles.update(neighbourhood.partners)
                 self.resolve_neighbourhood(neighbourhood)
-                report(str(i) + " / " + str(t), level=3, ongoing=True)
+                if not i % 100:
+                    report(str(i) + " / " + str(t), level=3, ongoing=True)
             # Double check that there's no collisions left
             self.freeze()
             self.find_colliding_particles()


### PR DESCRIPTION
## Describe the work done

When using labels, or empty morphologies, `TouchDetector` would burn the house down. It has been told not to do that.

closes #319.