### PR TITLE
FIx unknown morphology `b'name'`

### DIFF
--- a/bsb/configurations/mouse_cerebellum_cortex.json
+++ b/bsb/configurations/mouse_cerebellum_cortex.json
@@ -518,7 +518,7 @@
           "targetting": "by_label",
           "labels": ["grc_active_dends_*"],
           "cell_count": 2,
-          "section_type": "soma"
+          "section_types": ["soma"]
         }
       }
     }

--- a/bsb/core.py
+++ b/bsb/core.py
@@ -590,6 +590,10 @@ class Scaffold:
                 data += len(attr_data[map_name])
             mapped_data = np.array(data, dtype=int)
         else:
+            if data.dtype.type is np.string_:
+                # Explicitly cast numpy strings to str so they don't yield
+                # `b'morphology_name'` when stored as attribute by hdf5.
+                data = data.astype(str)
             mapped_data, data_map = map_ndarray(data, _map=attr_data[map_name])
             mapped_data = np.array(mapped_data, dtype=int)
         attr_data[map_name].extend(data_map)

--- a/bsb/helpers.py
+++ b/bsb/helpers.py
@@ -591,9 +591,9 @@ def map_ndarray(data, _map=None):
         if len(a.shape) > 1:
             for i, b in enumerate(a):
                 n[i] = n_dim_map(b)
-            return n
         else:
-            return list(map(map_1d_array, a))
+            n[:] = list(map(map_1d_array, a))
+        return n
 
     _mapped = n_dim_map(data)
     return _mapped, _map

--- a/bsb/output.py
+++ b/bsb/output.py
@@ -438,6 +438,8 @@ class MorphologyRepository(HDF5TreeHandler):
         """
         Load a morphology from repository data
         """
+        if name.startswith("b'"):
+            name = name[2:-1]
         with self.load() as handler:
             # Check if morphology exists
             if not self.morphology_exists(name):

--- a/bsb/output.py
+++ b/bsb/output.py
@@ -438,8 +438,6 @@ class MorphologyRepository(HDF5TreeHandler):
         """
         Load a morphology from repository data
         """
-        if name.startswith("b'"):
-            name = name[2:-1]
         with self.load() as handler:
             # Check if morphology exists
             if not self.morphology_exists(name):


### PR DESCRIPTION
Morphology names were being serialized into the string representations of bytestrings (`b'string value here'`) by h5py when they were converted from numpy's `S` dtypes into hdf5 attributes.