### PR TITLE
Fix errors with identifier assignment and continuity

### DIFF
--- a/bsb/configurations/mouse_cerebellum_cortex.json
+++ b/bsb/configurations/mouse_cerebellum_cortex.json
@@ -403,8 +403,8 @@
         "parallel_fiber_to_stellate": {
           "synapses": ["AMPA", "NMDA"]
         },
-	       "basket_to_purkinje": {
-	          "synapses": ["GABA"]
+	      "basket_to_purkinje": {
+          "synapses": ["GABA"]
 	      },
         "stellate_to_purkinje": {
           "synapses": ["GABA"]
@@ -482,7 +482,7 @@
           "device": "spike_generator",
           "targetting": "by_label",
           "labels": ["central_mossy_fibers"],
-          "synapses": [],
+          "synapses": ["AMPA", "NMDA"],
           "spike_times": [6000.0, 6003.0, 6006.0, 6012.0, 6020.0]
         },
         "mossy_fiber_input_sync_imp": {

--- a/bsb/connectivity/connectome/glomerulus_golgi.py
+++ b/bsb/connectivity/connectome/glomerulus_golgi.py
@@ -39,7 +39,7 @@ class ConnectomeGlomerulusGolgi(ConnectionStrategy):
         first_glomerulus = int(glomeruli[0, 0])
         r_goc_vol = golgi_cell_type.morphology.dendrite_radius
         if self.detailed:
-            compartments = np.zeros((0, 2))
+            compartments = np.ones((0, 2)) * -1
             comps = self.dendritic_compartments
             total_compartments = len(comps)
 
@@ -78,7 +78,7 @@ class ConnectomeGlomerulusGolgi(ConnectionStrategy):
                     # Compose an empty connection matrix to hold the connection records
                     matrix = np.zeros((total_contacts, 2))
                     # Holds the connection_compartments for this golgi cell
-                    gg_comps = np.zeros(matrix.shape)
+                    gg_comps = np.ones(matrix.shape) * -1
                     # Draw rolls from the exponential distribution equal to the total amount
                     # of synaptic contacts to be made between this Golgi cell and all its
                     # glomeruli.

--- a/bsb/connectivity/connectome/glomerulus_granule.py
+++ b/bsb/connectivity/connectome/glomerulus_granule.py
@@ -127,7 +127,7 @@ class ConnectomeGlomerulusGranule(ConnectionStrategy):
                     raise ConnectivityError(
                         "Attempt to connect a glomerulus to a fully saturated granule cell."
                     )
-                compartments.append([0, unoccupied_claw])
+                compartments.append([-1, unoccupied_claw])
             self.scaffold.connect_cells(
                 self,
                 connectome,

--- a/bsb/core.py
+++ b/bsb/core.py
@@ -943,7 +943,7 @@ class Scaffold:
         beginnings = set()
         ends = dict()
         for ct in self.get_cell_types():
-            stretch = ct.get_placement_set().identifier_set.get_dataset()
+            stretch = ct.get_placement_set()._identifiers.get_dataset()
             if len(stretch) != 2:
                 raise ContinuityError(
                     f"Discontinuities in `{ct.name}`:"

--- a/bsb/exceptions.py
+++ b/bsb/exceptions.py
@@ -37,6 +37,7 @@ _t(
                 ReceptorSpecificationError=_e(),
             ),
             ParallelIntegrityError=_e("rank"),
+            ArborError=_e(),
         ),
         ConnectivityError=_e(
             ExternalSourceError=_e(

--- a/bsb/models.py
+++ b/bsb/models.py
@@ -478,12 +478,12 @@ class PlacementSet(Resource):
             raise DatasetNotFoundError("PlacementSet '{}' does not exist".format(tag))
         self.type = cell_type
         self.tag = tag
-        identifier_resource = Resource(handler, root + tag + "/identifiers")
+        self._identifiers = Resource(handler, root + tag + "/identifiers")
         self._filter = f = _Filter()
 
         def id_source():
             return np.array(
-                expand_continuity_list(identifier_resource.get_dataset()), dtype=int
+                expand_continuity_list(self._identifiers.get_dataset()), dtype=int
             )
 
         self._filter.filter_source = id_source

--- a/bsb/models.py
+++ b/bsb/models.py
@@ -536,7 +536,7 @@ class PlacementSet(Resource):
         ]
 
     def __iter__(self):
-        id_iter = iterate_continuity_list(self.identifier_set.get_dataset())
+        id_iter = iterate_continuity_list(self._identifiers.get_dataset())
         iterators = [iter(id_iter), self._none(), self._none()]
         if self.positions_set.exists():
             iterators[1] = iter(self.positions)
@@ -545,7 +545,7 @@ class PlacementSet(Resource):
         return zip(*iterators)
 
     def __len__(self):
-        return count_continuity_list(self.identifier_set)
+        return count_continuity_list(self._identifiers)
 
     def _none(self):
         """

--- a/bsb/output.py
+++ b/bsb/output.py
@@ -438,6 +438,8 @@ class MorphologyRepository(HDF5TreeHandler):
         """
         Load a morphology from repository data
         """
+        if name.startswith("b'"):
+            name = name[2:-1]
         with self.load() as handler:
             # Check if morphology exists
             if not self.morphology_exists(name):

--- a/bsb/simulators/arbor/adapter.py
+++ b/bsb/simulators/arbor/adapter.py
@@ -234,7 +234,7 @@ class QuickContains:
             self._kind = arbor.cell_kind.cable
         self._ranges = [
             (start, start + count)
-            for start, count in continuity_hop(iter(ps.identifier_set.get_dataset()))
+            for start, count in continuity_hop(iter(ps._identifiers.get_dataset()))
         ]
 
     def __contains__(self, i):
@@ -259,7 +259,7 @@ class QuickLookup:
         try:
             return next(c for c in self._contains if gid in c)
         except StopIteration:
-            raise GidLookupError(f"Can't find gid {gid}.")
+            raise UnknownGIDError(f"Can't find gid {gid}.") from None
 
 
 class ArborRecipe(arbor.recipe):

--- a/bsb/simulators/arbor/adapter.py
+++ b/bsb/simulators/arbor/adapter.py
@@ -95,6 +95,9 @@ class ArborCell(SimulationCell):
         pwlin = arbor.place_pwlin(morphology)
 
         def comp_label(comp):
+            if comp.id == -1:
+                warn(f"Encountered nil compartment on {gid}")
+                return
             loc, d = pwlin.closest(*comp.start)
             if d > 0.0001:
                 raise AdapterError(f"Couldn't find {comp.start}, on {self._str(gid)}")
@@ -104,6 +107,7 @@ class ArborCell(SimulationCell):
         comps_on = (rcv.comp_on for rcv in self.adapter._connections_on[gid])
         gaps = (c.to_compartment for c in self.adapter._gap_junctions_on.get(gid, []))
         it.consume(comp_label(i) for i in it.chain(comps_from, comps_on, gaps))
+        labels[self.default_endpoint] = "(root)"
         return labels
 
     def _str(self, gid):


### PR DESCRIPTION
The new filtered PlacementSets caused direct access to the `identifier_set` to misbehave, fixed by adding a private `_identifiers` when the raw dataset is needed.

Also made sure that connections to cells without morphologies to use comp -1 (nil compartment)