### PR TITLE
Ensure labels are vectors

### DIFF
--- a/bsb/output.py
+++ b/bsb/output.py
@@ -848,8 +848,10 @@ class HDF5Formatter(OutputFormatter, MorphologyRepository):
 
     def store_labels(self, cells_group):
         labels_group = cells_group.create_group("labels")
-        for label in self.scaffold.labels.keys():
-            labels_group.create_dataset(label, data=self.scaffold.labels[label])
+        for label, data in self.scaffold.labels.items():
+            # Make sure the data is one-dimensional
+            vector = np.array(data).reshape(-1)
+            labels_group.create_dataset(label, data=vector)
 
     def store_statistics(self):
         with self.load("a") as f:

--- a/bsb/simulation/targetting.py
+++ b/bsb/simulation/targetting.py
@@ -116,6 +116,7 @@ class TargetsNeurons:
             else:
                 n = total
             n = max(0, min(n, total))
+            print(labelled)
             targets.extend(random.sample(list(labelled), n))
         return targets
 

--- a/bsb/simulation/targetting.py
+++ b/bsb/simulation/targetting.py
@@ -116,7 +116,6 @@ class TargetsNeurons:
             else:
                 n = total
             n = max(0, min(n, total))
-            print(labelled)
             targets.extend(random.sample(list(labelled), n))
         return targets
 


### PR DESCRIPTION
Some adapter errors occured if label data was of shape `(N. 1)` instead of `(N.)`