### PR TITLE
Fixed `in_classmap` type handler returning bool instead of value

### DIFF
--- a/bsb/config/types.py
+++ b/bsb/config/types.py
@@ -561,12 +561,20 @@ def in_classmap():
     """
 
     def type_handler(value, _parent, _key=None):
+        class_name = _parent.__class__.__name__
         if not hasattr(_parent.__class__, "_config_dynamic_classmap"):
             raise ClassMapMissingError(
-                "Class map missing for '{}'".format(_parent.__class__.__name__)
+                f"Class map missing for `{class_name}`,"
+                + " required when using `in_classmap` type handler."
             )
-
-        return value in _parent.__class__._config_dynamic_classmap
+        classmap = _parent.__class__._config_dynamic_classmap
+        if value not in classmap:
+            classmap_str = ", ".join(f"'{key}'" for key in classmap)
+            raise TypeError(
+                f"'{value}' is not a valid classmap identifier for `{class_name}`."
+                + f" Choose from: {classmap_str}"
+            )
+        return value
 
     type_handler.__name__ = "a classmap value"
     return type_handler

--- a/bsb/config/types.py
+++ b/bsb/config/types.py
@@ -570,7 +570,7 @@ def in_classmap():
         classmap = _parent.__class__._config_dynamic_classmap
         if value not in classmap:
             classmap_str = ", ".join(f"'{key}'" for key in classmap)
-            raise TypeError(
+            raise CastError(
                 f"'{value}' is not a valid classmap identifier for `{class_name}`."
                 + f" Choose from: {classmap_str}"
             )

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -5,8 +5,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 from bsb.core import Scaffold
 from bsb import config
 from bsb.config import from_json, Configuration
+from bsb.config import types
 from bsb.exceptions import *
-from bsb.models import Layer, CellType
 
 
 def relative_to_tests_folder(path):
@@ -644,9 +644,6 @@ class TestWalk(unittest.TestCase):
         self.assertEqual(len(iter_collected), 7)
 
 
-from bsb.config import types
-
-
 class TestTypes(unittest.TestCase):
     def test_in(self):
         @config.node
@@ -889,7 +886,6 @@ class TestTypes(unittest.TestCase):
         with self.assertRaises(CastError):
             cfg = Test({"a": "MyTestClass"})
 
-    @unittest.expectedFailure
     def test_in_classmap(self):
         @config.root
         class Test:
@@ -910,11 +906,11 @@ class TestTypes(unittest.TestCase):
         # If a string is invalid a cast error should be raised
         with self.assertRaises(CastError):
             Classmap2Parent.cls.type("aa", _parent=t.c, _key="cls")
-        # To whoever fixes the classmaps: This might start throwing an error because d
-        # is not mapped to an actual class; The type validator however shouldn't complain.
-        # It should only check whether the given value is in the classmap or not. If an
-        # error occurs outside of the type handler that's supposed to happen.
-        self.assertEqual("d", Test(c="d"))
+        # `d` is in the classmap, but not mapped to an actual class. This test verifies
+        # that the `in_classmap` type handler will nod and allow `d` to be pass and burn
+        # later on, where it is supposed to burn.
+        with self.assertRaises(UnresolvedClassCastError):
+            self.assertEqual("d", Test(c={"cls": "d"}))
 
 
 @config.dynamic(


### PR DESCRIPTION
## Describe the work done

Type handlers should error in incorrect cases, and return the parsed value. `in_classmap` was returning a bool validating the input, replacing the parsed value leading to #343.

## List which issues this resolves:

closes #343, closes #165

## Tasks

* [X] Added tests
