### PR TITLE
Added better existence check in `compile`

### DIFF
--- a/bsb/core.py
+++ b/bsb/core.py
@@ -220,14 +220,14 @@ class Scaffold:
         """
         Run reconstruction steps in the scaffold sequence to obtain a full network.
         """
-        exists = self.storage.exists()
+        existed = self.storage.preexisted
         p_strats = self.get_placement(skip=skip, only=only)
         c_strats = self.get_connectivity(skip=skip, only=only)
         todo_list_str = ", ".join(s.name for s in itertools.chain(p_strats, c_strats))
         report(f"Compiling the following strategies: {todo_list_str}", level=2)
         if sum((clear, redo, append)) > 1:
             raise InputError("`clear`, `redo` and `append` are mutually exclusive.")
-        if exists:
+        if existed:
             if not (clear or append or redo):
                 raise FileExistsError(
                     f"The `{self.storage.format}` storage"

--- a/bsb/storage/__init__.py
+++ b/bsb/storage/__init__.py
@@ -172,8 +172,13 @@ class Storage:
                     self._engine.__dict__[key] = NotSupported(self._engine.format, name)
         # The storage should be created at the root as soon as we initialize because
         # features might immediatly require the basic structure to be present.
-        if not self.exists():
+        self._preexisted = self.exists()
+        if not self._preexisted:
             self.create()
+
+    @property
+    def preexisted(self):
+        return self._preexisted
 
     def is_master(self):
         return self._comm.Get_rank() == self._master


### PR DESCRIPTION
## Describe the work done

Fixes #358 so that you can compile new files without it claiming the file already existed. The `Storage` keeps a `preexisted` flag around that indicates whether the storage existed before it created itself.
