### PR TITLE
`group` should be the default Region, as it does nothing.

### DIFF
--- a/bsb/topology/region.py
+++ b/bsb/topology/region.py
@@ -7,7 +7,7 @@ from ..config import types, refs
 from ..exceptions import *
 
 
-@config.dynamic(required=False, default="stack", auto_classmap=True)
+@config.dynamic(required=False, default="group", auto_classmap=True)
 class Region:
     """
     Base region.


### PR DESCRIPTION
Stack messes with the user's expectation: they didn't enter any command 
to stack things, and things are being stacked.