### PR TITLE
SubTree call chaining

### DIFF
--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -270,6 +270,7 @@ class SubTree:
             if center is not None:
                 rotated_points += center
             b.x, b.y, b.z = rotated_points.T
+        return self
 
     def root_rotate(self, rot):
         """
@@ -278,6 +279,7 @@ class SubTree:
         for b in self.roots:
             group = SubTree([b])
             group.rotate(rot, group.origin)
+        return self
 
     def translate(self, point):
         if len(point) != 3:
@@ -286,6 +288,7 @@ class SubTree:
             for branch in self.branches:
                 array = getattr(branch, vector)
                 array += p
+        return self
 
     @property
     def origin(self):
@@ -293,6 +296,7 @@ class SubTree:
 
     def center(self):
         self.translate(-self.origin)
+        return self
 
     def close_gaps(self):
         for branch in self.branches:
@@ -300,12 +304,14 @@ class SubTree:
                 gap_offset = branch.parent[-1][:3] - branch[0][:3]
                 if not np.allclose(gap_offset, 0):
                     SubTree([branch]).translate(gap_offset)
+        return self
 
     def collapse(self, on=None):
         if on is None:
             on = self.origin
         for root in self.roots:
             root.translate(on - root[0][:3])
+        return self
 
     def voxelize(self, N, labels=None):
         if labels is not None:

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -289,7 +289,7 @@ class SubTree:
 
     @property
     def origin(self):
-        return np.mean([r.get_point(0) for r in self.roots], axis=0)
+        return np.mean([r[0][:3] for r in self.roots], axis=0)
 
     def center(self):
         self.translate(-self.origin)
@@ -297,7 +297,7 @@ class SubTree:
     def close_gaps(self):
         for branch in self.branches:
             if branch.parent is not None:
-                gap_offset = branch.parent.get_point(-1) - branch.get_point(0)
+                gap_offset = branch.parent[-1][:3] - branch[0][:3]
                 if not np.allclose(gap_offset, 0):
                     SubTree([branch]).translate(gap_offset)
 
@@ -305,7 +305,7 @@ class SubTree:
         if on is None:
             on = self.origin
         for root in self.roots:
-            root.translate(on - root.get_point(0))
+            root.translate(on - root[0][:3])
 
     def voxelize(self, N, labels=None):
         if labels is not None:

--- a/docs/morphologies/intro.rst
+++ b/docs/morphologies/intro.rst
@@ -254,6 +254,14 @@ Collapsing
 
 Collapse the roots of a subtree onto a single point, by default the origin.
 
+.. rubric:: Call chaining
+
+Calls to any of the above functions can be chained together:
+
+.. code-block:: python
+
+  dendrites.close_gaps().center().rotate(r)
+
 =====================
 Morphology preloading
 =====================

--- a/tests/test_morphologies.py
+++ b/tests/test_morphologies.py
@@ -5,6 +5,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 from bsb.morphologies import Morphology, Branch
 from bsb.storage.engines.hdf5 import morphology_repository as _mr_module
 from bsb.exceptions import *
+from scipy.spatial.transform import Rotation
 
 
 @unittest.skip("Re-enabling tests gradually while advancing v4.0 rework")
@@ -301,6 +302,18 @@ class TestMorphologies(unittest.TestCase):
         self.assertTrue(branch.is_terminal)
         branch.attach_child(Branch(*(np.ones(0) for i in range(len(Branch.vectors)))))
         self.assertFalse(branch.is_terminal)
+
+    def test_chaining(self):
+        branch = Branch(
+            np.array([0, 1, 2]),
+            np.array([0, 1, 2]),
+            np.array([0, 1, 2]),
+            np.array([0, 1, 2]),
+        )
+        m = Morphology([branch])
+        r = Rotation.from_euler("z", 0)
+        res = m.rotate(r).root_rotate(r).translate([0, 0, 0]).collapse().close_gaps()
+        self.assertEqual(m, res, "chaining calls should return self")
 
 
 class TestMorphologyLabels(unittest.TestCase):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -158,9 +158,6 @@ class TestUtil(unittest.TestCase):
             f.write("Your Highness?")
         link = _util.syslink(junk)
         self.assertTrue(link.exists())
-        f = link.get()
-        print(f, f.name, f.read())
-        f.close()
         with link.get() as f:
             self.assertEqual("Your Highness?", f.read(), "message")
         with link.get(binary=True) as f:


### PR DESCRIPTION
Calls to SubTree functions now return `self` where appropriate to allow call chaining. closes #354 

## Tasks

* [X] Added tests
* [X] Updated documentation
