### PR TITLE
Fix black check

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Black Check
-      uses: jpetrucciani/black-check@latest
+      uses: jpetrucciani/black-check@master
       with:
         path: 'bsb'

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Black Check
-      uses: jpetrucciani/black-check
+      uses: jpetrucciani/black-check@latest
       with:
         path: 'bsb'

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Black Check
-      uses: jpetrucciani/black-check@20.8b1
+      uses: jpetrucciani/black-check
       with:
         path: 'bsb'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -1193,7 +1193,7 @@ def _import(cls, branch_cls, file):
     roots = []
     counter = itertools.count(1)
     ptr = 0
-    while (i := next(counter)) :
+    while i := next(counter):
         try:
             parent, section = section_stack.pop()
         except IndexError:

--- a/bsb/particles.py
+++ b/bsb/particles.py
@@ -22,7 +22,7 @@ class Particle:
 
     def displace_by(self, other):
         A = self.position - other.position
-        d = np.sqrt(np.sum(A ** 2))
+        d = np.sqrt(np.sum(A**2))
         collision_radius = self.radius + other.radius
         f = Particle.get_displacement_force(collision_radius, d)
         f_inert = f * other.volume / (other.volume + self.volume)
@@ -461,7 +461,7 @@ def get_particle_trace(particle):
 
 
 def sphere_volume(radius):
-    return 4 / 3 * np.pi * radius ** 3
+    return 4 / 3 * np.pi * radius**3
 
 
 def distance(a, b):

--- a/bsb/placement/satellite.py
+++ b/bsb/placement/satellite.py
@@ -81,7 +81,7 @@ class Satellite(PlacementStrategy):
             planet_ids = planet_cells.load_identifiers()
             planets_pos = planet_cells.load_positions()
             planet_count = len(planets_pos)
-            dist = np.empty((planet_count ** 2))
+            dist = np.empty((planet_count**2))
             for I in range(planet_count):
                 for J in range(planet_count):
                     dist[I * planet_count + J] = np.linalg.norm(

--- a/bsb/storage/_chunks.py
+++ b/bsb/storage/_chunks.py
@@ -66,6 +66,6 @@ class Chunk(np.ndarray):
 
     @classmethod
     def from_id(cls, id, size):
-        raw = [id % 2 ** 17, id // 2 ** 16 % 2 ** 17, id // 2 ** 32 % 2 ** 17]
+        raw = [id % 2**17, id // 2**16 % 2**17, id // 2**32 % 2**17]
         unpacked = np.array(raw, dtype=np.uint16).astype(np.int16)
         return cls(unpacked, size)


### PR DESCRIPTION
`black` had some dependency issues with `click`, so we now use the `master` black checks (the `black-check` doesn't have a tag for `22.3.0`, see https://github.com/jpetrucciani/black-check/issues/13)