### PR TITLE
Split `only` and `skip` based on commas as well

### DIFF
--- a/bsb/cli/commands/_commands.py
+++ b/bsb/cli/commands/_commands.py
@@ -7,6 +7,7 @@ from ...option import BsbOption
 from ...exceptions import *
 from ..._options import ConfigOption
 from . import _projects
+import itertools
 
 
 class XScale(BsbOption, name="x", cli=("x",), env=("BSB_CONFIG_NETWORK_X",)):
@@ -95,6 +96,13 @@ class SkipAfterConnectivity(
     pass
 
 
+def _flatten_arr_args(arr):
+    if arr is None:
+        return arr
+    else:
+        return list(itertools.chain.from_iterable(a.split(",") for a in arr))
+
+
 class MakeConfigCommand(BaseCommand, name="make-config"):
     def handler(self, context):
         from ...config import copy_template
@@ -131,8 +139,8 @@ class BsbCompile(BaseCommand, name="compile"):
             skip_after_placement=context.skip_after_placement,
             skip_connectivity=context.skip_connectivity,
             skip_after_connectivity=context.skip_after_connectivity,
-            only=context.only,
-            skip=context.skip,
+            only=_flatten_arr_args(context.only),
+            skip=_flatten_arr_args(context.skip),
             clear=context.clear,
             force=context.force,
             append=context.append,


### PR DESCRIPTION
Allows `skip` and `only` flags to be given in a comma separated format as well. closes #397 