### PR TITLE
Fixed indicator inheritance

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Expect everything to be broken, configs needs to be translated to v4
 ### Breaking changes
 
 * `morphological` changed to `morphologies`.
+* `geometrical` changed to `geometry`.
 
 # 3.10 - Arbor
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+# 4.0.0 - Too much to list
+
+Expect everything to be broken, configs needs to be translated to v4
+
+## 4.0.0a7
+
+### Breaking changes
+
+* `morphological` changed to `morphologies`.
+
+# 3.10 - Arbor
+
+* Added a very basic Arbor adapter
+
 # 3.9
 
 ## 3.9.0 - Partial (re)connecting, network merging and repeated NEST simulations

--- a/bsb/__init__.py
+++ b/bsb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.0.0a6"
+__version__ = "4.0.0a7"
 
 import functools
 

--- a/bsb/cell_types.py
+++ b/bsb/cell_types.py
@@ -11,43 +11,6 @@ from .exceptions import *
 import abc
 
 
-@config.dynamic(
-    attr_name="selector",
-    auto_classmap=True,
-    required=False,
-    default="by_name",
-)
-class MorphologySelector(abc.ABC):
-    @abc.abstractmethod
-    def validate(self, all_morphos):
-        pass
-
-    @abc.abstractmethod
-    def pick(self, morphology):
-        pass
-
-
-@config.node
-class NameSelector(MorphologySelector, classmap_entry="by_name"):
-    names = config.list(type=str)
-
-    def validate(self, all_morphos):
-        missing = set(self.names) - {m.get_meta()["name"] for m in all_morphos}
-        if missing:
-            raise MissingMorphologyError(
-                f"Morphology repository misses the following morphologies required by {self._config_parent._config_parent.get_node_name()}: {', '.join(missing)}"
-            )
-
-    def pick(self, morphology):
-        return morphology.get_meta()["name"] in self.names
-
-
-@config.node
-class Representation(PlacementIndications):
-    geometrical = config.dict(type=types.any())
-    morphological = config.list(type=MorphologySelector)
-
-
 @config.node
 class Plotting:
     display_name = config.attr()
@@ -67,7 +30,7 @@ class CellType:
 
     name = config.attr(key=True)
     spatial = config.attr(
-        type=Representation, required=_not_an_entity, default={"radius": None}
+        type=PlacementIndications, required=_not_an_entity, default={"radius": None}
     )
     plotting = config.attr(type=Plotting)
     relay = config.attr(type=bool, default=False)

--- a/bsb/placement/strategy.py
+++ b/bsb/placement/strategy.py
@@ -68,7 +68,7 @@ class RandomMorphologies(MorphologyDistributor, classmap_entry="random"):
         Uses the morphology selection indicators to select morphologies and
         returns a MorphologySet of randomly assigned morphologies
         """
-        selectors = indicator.assert_indication("morphological")
+        selectors = indicator.assert_indication("morphologies")
         loaders = self.scaffold.storage.morphologies.select(*selectors)
         if not loaders:
             raise EmptySelectionError(

--- a/bsb/postprocessing.py
+++ b/bsb/postprocessing.py
@@ -105,7 +105,7 @@ class AscendingAxonLengths(PostProcessingHook):
     def after_placement(self):
         granule_type = self.scaffold.cell_types.granule_cell
         granules = self.scaffold.get_placement_set(granule_type.name)
-        granule_geometry = granule_type.spatial.geometrical
+        granule_geometry = granule_type.spatial.geometry
         parallel_fibers = np.zeros((len(granules)))
         pf_height = granule_geometry.pf_height
         pf_height_sd = granule_geometry.pf_height_sd

--- a/docs/config/_full_cell_type_node.rst
+++ b/docs/config/_full_cell_type_node.rst
@@ -6,7 +6,7 @@
         "entity": false,
         "spatial": {
           "radius": 10.0,
-          "geometrical": {
+          "geometry": {
             "axon_length": 150.0,
             "other_hints": "hi!"
           },

--- a/docs/config/_full_cell_type_node.rst
+++ b/docs/config/_full_cell_type_node.rst
@@ -10,7 +10,7 @@
             "axon_length": 150.0,
             "other_hints": "hi!"
           },
-          "morphological": [
+          "morphologies": [
             {
               "selector": "by_name",
               "names": ["short_*"]

--- a/docs/morphologies/intro.rst
+++ b/docs/morphologies/intro.rst
@@ -269,9 +269,9 @@ Morphology selectors
 --------------------
 
 The most common way of telling the framework which morphologies to use is through
-:class:`MorphologySelectors <.cell_types.MorphologySelector>`. A selector should
-implement :meth:`~.cell_types.MorphologySelector.validate` and
-:meth:`~.cell_types.MorphologySelector.pick` methods.
+:class:`MorphologySelectors <.placement.indicator.MorphologySelector>`. A selector should
+implement :meth:`~.placement.indicator.MorphologySelector.validate` and
+:meth:`~.placement.indicator.MorphologySelector.pick` methods.
 
 ``validate`` can be used to assert that all the required morphologies are present, while
 ``pick`` needs to return ``True``/``False`` to include a morphology or not. Both methods

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ scipy==1.6.0
 rtree==0.9.7
 plotly==4.14.3
 pre-commit==1.21.0
-black==20.8b1
+black==22.3.0
 nrn-patch==3.0.0
 dbbs_models==2.0.0dev3
 colour==0.1.5

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setuptools.setup(
             "sphinx",
             "furo",
             "pre-commit",
-            "black==20.8b1",
+            "black==22.3.0",
             "nrn-subprocess==1.3.4",
             "sphinxemoji",
             "sphinx_design",

--- a/tests/data/configs/test_full_v4.json
+++ b/tests/data/configs/test_full_v4.json
@@ -54,7 +54,7 @@
       "spatial": {
         "radius": 2.5,
         "density": 3.9e-3,
-        "geometrical": {
+        "geometry": {
           "pf_height": 126,
           "pf_height_sd": 15
         }


### PR DESCRIPTION
## Describe the work done

`morphological` and `geometrical` were missing from the indicators, because `Representation` added these one, but weren't part of `PlacementIndications`. Now `Representation` is removed, and `PlacementIndications` contains all information.

**Breaking changes alpha 7**: `morphological` renamed to `morphologies`; `geometrical` renamed to `geometry`.

PS: I will now start keeping a better CHANGELOG