### PR TITLE
Copied configuration dictionaries can now display node name on error.

### DIFF
--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -464,12 +464,28 @@ class cfgdict(_dict):
                 self.get_node_name() + " object has no attribute '{}'".format(name)
             )
 
+    def copy(self):
+        return cfgdictcopy(self)
+
     @builtins.property
     def _config_attr_name(self):
         return self._config_attr.attr_name
 
     def get_node_name(self):
         return self._config_parent.get_node_name() + "." + self._config_attr_name
+
+
+class cfgdictcopy(cfgdict):
+    def __init__(self, other):
+        super().__init__(other)
+        self._copied_from = other
+
+    @builtins.property
+    def _config_attr_name(self):
+        return self._copied_from._config_attr_name
+
+    def get_node_name(self):
+        return self._copied_from.get_node_name()
 
 
 class ConfigurationDictAttribute(ConfigurationAttribute):

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,0 +1,29 @@
+import unittest, os, sys, numpy as np, h5py, json
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+from bsb.core import Scaffold
+from bsb import config
+from bsb.config import from_json, Configuration
+from bsb.config import types
+from bsb.exceptions import *
+from test_setup import get_config
+from bsb.topology import Region, Partition
+
+
+def relative_to_tests_folder(path):
+    return os.path.join(os.path.dirname(__file__), path)
+
+
+@config.root
+class Root430:
+    regions = config.dict(type=Region)
+    partitions = config.dict(type=Partition, required=True)
+
+
+class TestIssues(unittest.TestCase):
+    def test_430(self):
+        with self.assertRaises(ReferenceError, msg="Regression of issue #430"):
+            config = Root430(
+                regions=dict(), partitions=dict(x=dict(region="missing", thickness=10))
+            )


### PR DESCRIPTION
## Describe the work done

There was a bug in the `RegionalRef` reference lambda, which can reference both partitions and regions, because a copy of a `cfgdict` was created, and a regular `dict` returned, which doesn't have a `get_node_name` method. When an invalid reference was given, this method is called to show where in the config the problem is, but instead the cryptic error of #430 was shown.

## List which issues this resolves:

closes #430

## Tasks

* [X] Added tests
