### PR TITLE
Morphology loading with meta dictionary

### DIFF
--- a/bsb/storage/engines/hdf5/morphology_repository.py
+++ b/bsb/storage/engines/hdf5/morphology_repository.py
@@ -89,7 +89,9 @@ class MorphologyRepository(Resource, IMorphologyRepository):
                     ptr = nptr
                 meta = _meta(root)
                 meta["name"] = name
-                morpho = Morphology(roots, meta, shared_buffers=(points, radii, labels, props))
+                morpho = Morphology(
+                    roots, meta, shared_buffers=(points, radii, labels, props)
+                )
                 assert morpho._check_shared(), "Morpho read with unshareable buffers"
                 return morpho
 

--- a/bsb/storage/engines/hdf5/morphology_repository.py
+++ b/bsb/storage/engines/hdf5/morphology_repository.py
@@ -87,7 +87,9 @@ class MorphologyRepository(Resource, IMorphologyRepository):
                     else:
                         roots.append(branch)
                     ptr = nptr
-                morpho = Morphology(roots, shared_buffers=(points, radii, labels, props))
+                meta = _meta(root)
+                meta["name"] = name
+                morpho = Morphology(roots, meta, shared_buffers=(points, radii, labels, props))
                 assert morpho._check_shared(), "Morpho read with unshareable buffers"
                 return morpho
 

--- a/tests/test_morphologies.py
+++ b/tests/test_morphologies.py
@@ -206,6 +206,14 @@ class TestRepositories(unittest.TestCase):
     def test_tree_with_empty_branches(self):
         pass
 
+    def test_meta(self):
+        m = Morphology.from_swc(get_morphology("PurkinjeCell.swc"))
+        mr = Storage("hdf5", "test4.h5").morphologies
+        mr.save("pc", m)
+        m = mr.load("pc")
+        self.assertIn("mdc", m.meta, "missing mdc in loaded morphology")
+        self.assertIn("ldc", m.meta, "missing ldc in loaded morphology")
+
 
 class TestMorphologies(NumpyTestCase, unittest.TestCase):
     @classmethod

--- a/tests/test_morphologies.py
+++ b/tests/test_morphologies.py
@@ -209,7 +209,7 @@ class TestRepositories(unittest.TestCase):
     def test_meta(self):
         m = Morphology.from_swc(get_morphology("PurkinjeCell.swc"))
         mr = Storage("hdf5", "test4.h5").morphologies
-        mr.save("pc", m)
+        mr.save("pc", m, overwrite=True)
         m = mr.load("pc")
         self.assertIn("mdc", m.meta, "missing mdc in loaded morphology")
         self.assertIn("ldc", m.meta, "missing ldc in loaded morphology")


### PR DESCRIPTION
Added `meta` arg in the morphology returned by the `load` function