### PR TITLE
Morphologies labelling fix

### DIFF
--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -996,17 +996,17 @@ class _Labels(np.ndarray):
             if point in _transitions:
                 return _transitions[point]
             else:
-                trans_labels = self.labels[point].copy()
+                trans_labels = self.labels[str(point)].copy()
                 trans_labels.update(labels)
                 for k, v in self.labels.items():
                     if trans_labels == v:
                         return k
-                else:
-                    transition = next(counter)
-                    self.labels[transition] = trans_labels
-                    _transitions[point] = transition
-                    return transition
-
+                    else:
+                        transition = next(counter)
+                        self.labels[transition] = trans_labels
+                        _transitions[point] = transition
+                        return transition
+        
         self[points] = np.vectorize(transition)(self[points])
 
     def contains(self, *labels):


### PR DESCRIPTION
Fixes a `KeyError` when assigning labels to morphologies and a block with missing indentation  (`else` block without its corresponding `if`)