### PR TITLE
Fixed 2d indexing of VoxelData class

### DIFF
--- a/bsb/voxels.py
+++ b/bsb/voxels.py
@@ -19,7 +19,6 @@ class VoxelData(np.ndarray):
     """
 
     def __new__(cls, data, keys=None):
-        print("NEW VD", cls, data.shape, keys)
         if data.ndim == 1:
             cls = np.ndarray
         obj = super().__new__(cls, data.shape, dtype=object)

--- a/bsb/voxels.py
+++ b/bsb/voxels.py
@@ -19,8 +19,8 @@ class VoxelData(np.ndarray):
     """
 
     def __new__(cls, data, keys=None):
-        if data.ndim == 1:
-            cls = np.ndarray
+        if data.ndim < 2:
+            return super().__new__(np.ndarray, data.shape, dtype=object)
         obj = super().__new__(cls, data.shape, dtype=object)
         obj[:] = data
         if keys is not None:
@@ -186,6 +186,12 @@ class VoxelSet:
         if voxels.ndim == 1:
             voxels = voxels.reshape(-1, 3)
         return VoxelSet(voxels, voxel_size, data)
+
+    def __getattr__(self, key):
+        if key in self._data._keys:
+            return self.get_data(key)
+        else:
+            return super().__getattribute__(key)
 
     def __str__(self):
         cls = type(self)

--- a/bsb/voxels.py
+++ b/bsb/voxels.py
@@ -776,7 +776,7 @@ def _repeat_first():
     first = None
 
     def repeater(val):
-        nonlocal _set
+        nonlocal _set, first
         if not _set:
             first, _set = val, True
         return first

--- a/bsb/voxels.py
+++ b/bsb/voxels.py
@@ -19,8 +19,6 @@ class VoxelData(np.ndarray):
     """
 
     def __new__(cls, data, keys=None):
-        if data.ndim < 2:
-            data = data.reshape(-1, 1)
         obj = super().__new__(cls, data.shape, dtype=object)
         obj[:] = data
         if keys is not None:
@@ -139,6 +137,9 @@ class VoxelSet:
                     self._data = VoxelData(data, keys=data_keys)
             else:
                 data = np.array(data, copy=False)
+                if data.ndim < 2:
+                    cols = len(data_keys) if data_keys else 1
+                    data = data.reshape(-1, cols)
                 self._data = VoxelData(data, keys=data_keys)
             if len(self._data) != len(voxels):
                 raise ValueError("`voxels` and `data` length unequal.")

--- a/bsb/voxels.py
+++ b/bsb/voxels.py
@@ -19,6 +19,9 @@ class VoxelData(np.ndarray):
     """
 
     def __new__(cls, data, keys=None):
+        print("NEW VD", cls, data.shape, keys)
+        if data.ndim == 1:
+            cls = np.ndarray
         obj = super().__new__(cls, data.shape, dtype=object)
         obj[:] = data
         if keys is not None:
@@ -33,15 +36,11 @@ class VoxelData(np.ndarray):
         return obj
 
     def __getitem__(self, index):
-        if self.ndim > 1:
-            index, keys = self._rewrite_index(index)
+        index, keys = self._rewrite_index(index)
         vd = super().__getitem__(index)
         if isinstance(vd, VoxelData):
-            if vd.ndim == 1:
-                if keys:
-                    vd = vd.reshape(-1, len(keys))
-                else:
-                    vd = vd.reshape(-1, self.shape[1])
+            if len(keys) > 0 and len(vd) != vd.size / len(keys):
+                vd = vd.reshape(-1, len(keys))
             vd._keys = keys
         return vd
 
@@ -76,7 +75,7 @@ class VoxelData(np.ndarray):
                 index = (slice(None),)
             else:
                 index = (index,)
-                cols = slice(None)
+                cols = None
                 keys = getattr(self, "_keys", [])
         except ValueError as e:
             key = str(e).split("'")[1]

--- a/tests/test_voxels.py
+++ b/tests/test_voxels.py
@@ -132,6 +132,10 @@ class TestVoxelSet(test_setup.NumpyTestCase, unittest.TestCase):
         with self.assertRaises(ValueError):
             VoxelSet([[1, 0, 0, 0]], [[1, 0, 0]])
         VoxelSet([[1, 2, 3], [1, 2, 3]], 2, [[1], [2]], data_keys=["a"])
+        v = VoxelSet([[1, 2, 3], [1, 2, 3]], 2, [1, 2], data_keys=["a"])
+        self.assertEqual([[1], [2]], v.a.tolist(), "Voxel data should be 2d")
+        v = VoxelSet([[1, 2, 3]], 2, 1, data_keys=["a"])
+        self.assertEqual([[1]], v.a.tolist(), "Voxel data should be 2d")
         arr = np.array([[1], [2]])
         VoxelSet([[1, 2, 3], [1, 2, 3]], 2, VoxelData(arr))
         VoxelSet([[1, 2, 3], [1, 2, 3]], 2, VoxelData(arr), data_keys=["a"])
@@ -414,8 +418,9 @@ class TestVoxelSet(test_setup.NumpyTestCase, unittest.TestCase):
         self.assertEqual(1, vs.get_data(0))
         vs = VoxelSet.one([[100, 0, 0]], [120, 20, 20], [1])
         self.assertEqual(1, vs.get_data(0))
-        vs = VoxelSet.one([[100, 0, 0]], [120, 20, 20], [1, 1])
-        self.assertEqual([1, 1], list(np.array(vs.get_data(0))[0]))
+        vs = VoxelSet.one([100, 0, 0], [120, 20, 20], [1, 1])
+        self.assertEqual((1, 2), vs.get_data().shape, "incorrect interpretation of 2col")
+        self.assertEqual([1, 1], list(vs.get_data(0)))
 
     def test_index(self):
         for label, set in self.all.items():
@@ -507,14 +512,11 @@ class TestVoxelSet(test_setup.NumpyTestCase, unittest.TestCase):
 
 class TestVoxelData(unittest.TestCase):
     def test_ctor(self):
-        vd = VoxelData(np.array([1, 1, 1, 1]), keys=["alpha"])
-        self.assertEqual(2, vd.ndim, "VoxelData should be 2d")
-        vd = VoxelData(np.array(1), keys=["alpha"])
-        self.assertEqual(2, vd.ndim, "VoxelData should be 2d")
+        vd = VoxelData(np.array([[1], [1], [1], [1]]), keys=["alpha"])
         with self.assertRaises(IndexError):
             vd["beta"]
         with self.assertRaises(ValueError):
-            VoxelData(np.array([1, 1, 1]), keys=["a", "b", "c"])
+            VoxelData(np.array([[1], [1], [1]]), keys=["a", "b", "c"])
         with self.assertRaises(ValueError):
             VoxelSet(
                 [[0, 0, 0], [1, 0, 0], [2, 0, 0]],


### PR DESCRIPTION
`VoxelData` used to always be forced into a 2d shape, but this turned out to be a bad idea for `numpy` and UX reasons. Instead, the sanitization/shorthand of 1d VoxelData into a 2d shape is now only done in the `VoxelSet` constructor.