### PR TITLE
Allow wildcards in morphology name selector

### DIFF
--- a/bsb/placement/indicator.py
+++ b/bsb/placement/indicator.py
@@ -27,7 +27,7 @@ class NameSelector(MorphologySelector, classmap_entry="by_name"):
     names = config.list(type=str)
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__()
         self._names = {n: n.replace("*", r".*").replace("|", "\\|") for n in self.names}
         self._patterns = {n: re.compile(f"^{pat}$") for n, pat in self._names.items()}
         self._match = re.compile(f"^({'|'.join(self._names.values())})$")

--- a/bsb/placement/indicator.py
+++ b/bsb/placement/indicator.py
@@ -43,7 +43,8 @@ class NameSelector(MorphologySelector, classmap_entry="by_name"):
         if missing:
             err = "Morphology repository misses the following morphologies"
             if self._config_parent is not None:
-                err += f"required by {self._config_parent._config_parent.get_node_name()}"
+                node = self._config_parent._config_parent
+                err += f" required by {node.get_node_name()}"
             err += f": {', '.join(missing)}"
             raise MissingMorphologyError(err)
 

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -1,0 +1,53 @@
+import unittest, os, sys, numpy as np, h5py, json, string, random
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+from bsb.placement.indicator import NameSelector
+from bsb.config import from_json
+from bsb.exceptions import *
+from bsb.storage.interfaces import StoredMorphology
+
+
+def spoof(*names):
+    return [StoredMorphology(n, None, {"name": n}) for n in names]
+
+
+def spoof_combo(name, *names):
+    return [
+        StoredMorphology(n, None, {"name": n})
+        for n in [name + x for x in names] + [x + name for x in names]
+    ]
+
+
+class TestSelectors(unittest.TestCase):
+    def assertPicked(self, picks, sel, loaders, msg=None):
+        self.assertEqual(picks, [l.name for l in loaders if sel.pick(l)], msg=msg)
+
+    def test_strict_empty_name_selector(self):
+        ns = NameSelector(names=[])
+        all = spoof("A", "B", "*", "", "-", "0", "\\", "|", '"', ".*", "\\.")
+        ns.validate(all)
+        self.assertPicked([], ns, all, "Empty name selector should pick nothing")
+        none = spoof()
+        ns.validate(none)
+        self.assertPicked([], ns, none, "Empty name selector should pick nothing")
+
+    def test_strict_single_name_selector(self):
+        ns = NameSelector(names=["B"])
+        all = spoof("A", "B", "*", "", "-", "0", "\\", "|", '"', ".*", "\\.")
+        ns.validate(all)
+        self.assertPicked(["B"], ns, all, "Exact match to name expected")
+        none = spoof()
+        with self.assertRaises(MissingMorphologyError):
+            ns.validate(none)
+
+    def test_wild_single_name_selector(self):
+        ns = NameSelector(names=["B*"])
+        all = spoof_combo("B", "A", "B", "*", "-", "0", "\\", "|", '"', ".*", "\\.")
+        all += spoof("", "B")
+        ns.validate(all)
+        exp = ["BA", "BB", "B*", "B-", "B0", "B\\", "B|", 'B"', "B.*", "B\\.", "BB", "B"]
+        self.assertPicked(exp, ns, all, "Exact match to name expected")
+        none = spoof()
+        with self.assertRaises(MissingMorphologyError):
+            ns.validate(none)


### PR DESCRIPTION
Patterns can be matched with `*` representing 0 or more wildcard characters. E.g. `*cell-*` would match `cell-`, `cell-3`, `cell-3.2|w`, `ccccell-3.2|w`.