### PR TITLE
Initialize conn strats with empty queued jobs list

### DIFF
--- a/bsb/connectivity/strategy.py
+++ b/bsb/connectivity/strategy.py
@@ -42,6 +42,9 @@ class ConnectionStrategy(abc.ABC, SortableByAfter):
     postsynaptic = config.attr(type=HemitypeNode, required=True)
     after = config.reflist(refs.connectivity_ref)
 
+    def __boot__(self):
+        self._queued_jobs = []
+
     @classmethod
     def get_ordered(cls, objects):
         # No need to sort connectivity strategies, just obey dependencies.


### PR DESCRIPTION
## Describe the work done

If a conn strat isn't queued, its `_queued_jobs` attribute should be available so that dependencies know they don't have to wait for anything.

## List which issues this resolves:

fixes #445 
