### PR TITLE
Fixed windows stalling on pyproject search.

### DIFF
--- a/bsb/option.py
+++ b/bsb/option.py
@@ -353,7 +353,7 @@ class BsbOption:
 @functools.cache
 def _pyproject_content():
     path = pathlib.Path.cwd()
-    while str(path) != path.root:
+    while str(path)[len(path.drive) :] != path.root:
         proj = path / "pyproject.toml"
         if proj.exists():
             with open(proj, "r") as f:


### PR DESCRIPTION
## Describe the work done

The drive letter on windows caused path issues and got us stuck in an infinite loop on Windows.

## List which issues this resolves:

closes #428 
