### PR TITLE
Added autolink config settings

### DIFF
--- a/bsb/__init__.py
+++ b/bsb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.0.0a10"
+__version__ = "4.0.0a11"
 
 import functools
 

--- a/bsb/cli/commands/_projects.py
+++ b/bsb/cli/commands/_projects.py
@@ -49,11 +49,7 @@ class ProjectNewCommand(BaseCommand, name="new"):
                         "bsb": {
                             "config": output,
                             "links": {
-                                "config": [
-                                    "sys",
-                                    output,
-                                    "always",
-                                ],
+                                "config": "auto",
                                 "morpho": ["sys", "morphologies.hdf5", "newer"],
                             },
                         }

--- a/bsb/config/__init__.py
+++ b/bsb/config/__init__.py
@@ -137,7 +137,7 @@ class ConfigurationModule:
 
     def from_content(self, content, path=None):
         ext = path.split(".")[-1] if path is not None else None
-        parser, tree, meta = _try_parsers(content, self._parser_classes, ext)
+        parser, tree, meta = _try_parsers(content, self._parser_classes, ext, path=path)
         return _from_parsed(self, parser, tree, meta, path)
 
     __all__ = [*(vars().keys() - {"__init__", "__qualname__", "__module__"})]

--- a/bsb/config/_config.py
+++ b/bsb/config/_config.py
@@ -52,7 +52,6 @@ class Configuration:
         )
         merge_dicts(default_args, kwargs)
         conf = cls(default_args)
-        conf._meta = None
         conf._parser = "json"
         conf._file = None
         return conf

--- a/bsb/config/_make.py
+++ b/bsb/config/_make.py
@@ -213,6 +213,8 @@ def compile_postnew(cls, root=False):
 
 def wrap_root_postnew(post_new):
     def __post_new__(self, *args, _parent=None, _key=None, **kwargs):
+        if not hasattr(self, "_meta"):
+            self._meta = {"path": None, "produced": True}
         try:
             with warnings.catch_warnings(record=True) as log:
                 try:

--- a/bsb/config/parsers/json.py
+++ b/bsb/config/parsers/json.py
@@ -139,10 +139,6 @@ class json_imp(json_ref):
                 self.node[key] = target[key]
 
 
-class JsonMeta:
-    pass
-
-
 class JsonParser(Parser):
     """
     Parser plugin class to parse JSON configuration files.
@@ -157,20 +153,18 @@ class JsonParser(Parser):
         # the other documents are parsed by the standard json module (so no recursion yet)
         # After loading all required documents the references are resolved and all values
         # copied over to their final destination.
-        meta = JsonMeta()
-        meta.path = path
         if isinstance(content, str):
             content = parsed_dict(json.loads(content))
         self.root = content
         self.path = path or os.getcwd()
         self.is_doc = path and not os.path.isdir(path)
-        self.meta = meta
         self.references = []
         self.documents = {}
         self._traverse(content, content.items())
         self.resolved_documents = {}
         self._resolve_documents()
         self._resolve_references()
+        meta = {"path": path}
         return content, meta
 
     def _traverse(self, node, iter):

--- a/bsb/storage/__init__.py
+++ b/bsb/storage/__init__.py
@@ -157,9 +157,9 @@ class Storage:
         self._comm = comm or MPI.COMM_WORLD
         self._master = master
 
-        # Load the engine's interface onto the object, this allows consumer construction
-        # of features, but it is not advised. More properly the Storage object itself
-        # should provide factory methods.
+        # Load the engine's interface onto the object, this allows the end user to create
+        # features, but it is not advised. Usually the Storage object
+        # itself provides factory methods that should be used instead.
         for name, interface in _engines[engine].items():
             self.__dict__["_" + name] = interface
             # Interfaces can define an autobinding key so that singletons are available
@@ -199,6 +199,10 @@ class Storage:
     @property
     def root(self):
         return self._root
+
+    @property
+    def root_slug(self):
+        return self._engine.root_slug
 
     @property
     def format(self):

--- a/bsb/storage/engines/hdf5/__init__.py
+++ b/bsb/storage/engines/hdf5/__init__.py
@@ -23,6 +23,10 @@ class HDF5Engine(Engine):
             other, "_root", None
         )
 
+    @property
+    def root_slug(self):
+        return os.path.relpath(self._root)
+
     def _read(self):
         return self._lock.read()
 

--- a/bsb/storage/engines/hdf5/file_store.py
+++ b/bsb/storage/engines/hdf5/file_store.py
@@ -64,13 +64,16 @@ class FileStore(Resource, IFileStore):
             # It's a serialized Python dict, so it should be JSON readable. We don't use
             # evaluate because files might originate from untrusted sources.
             tree = json.loads(content)
-            return Configuration(**tree)
+            cfg = Configuration(**tree)
+            cfg._meta = type("ParserMeta", (), meta)
+            return cfg
 
     def store_active_config(self, config):
         id = self._active_config_id()
         if id is not None:
             self.remove(id)
-        return self.store(json.dumps(config.__tree__()), {"active_config": True})
+        meta = {"path": config._meta.path, "active_config": True}
+        return self.store(json.dumps(config.__tree__()), meta)
 
     def _active_config_id(self):
         match = (id for id, m in self.all().items() if m.get("active_config", False))

--- a/bsb/storage/engines/hdf5/file_store.py
+++ b/bsb/storage/engines/hdf5/file_store.py
@@ -73,7 +73,8 @@ class FileStore(Resource, IFileStore):
         if id is not None:
             self.remove(id)
         config._meta["active_config"] = True
-        return self.store(json.dumps(config.__tree__()), config._meta)
+        meta = {k: v for k, v in config._meta.items() if v is not None}
+        return self.store(json.dumps(config.__tree__()), meta)
 
     def _active_config_id(self):
         match = (id for id, m in self.all().items() if m.get("active_config", False))

--- a/bsb/storage/engines/hdf5/file_store.py
+++ b/bsb/storage/engines/hdf5/file_store.py
@@ -65,15 +65,15 @@ class FileStore(Resource, IFileStore):
             # evaluate because files might originate from untrusted sources.
             tree = json.loads(content)
             cfg = Configuration(**tree)
-            cfg._meta = type("ParserMeta", (), meta)
+            cfg._meta = meta
             return cfg
 
     def store_active_config(self, config):
         id = self._active_config_id()
         if id is not None:
             self.remove(id)
-        meta = {"path": config._meta.path, "active_config": True}
-        return self.store(json.dumps(config.__tree__()), meta)
+        config._meta["active_config"] = True
+        return self.store(json.dumps(config.__tree__()), config._meta)
 
     def _active_config_id(self):
         match = (id for id, m in self.all().items() if m.get("active_config", False))

--- a/bsb/storage/interfaces.py
+++ b/bsb/storage/interfaces.py
@@ -31,6 +31,11 @@ class Engine(Interface):
         # the name of the engine plugin.
         return self._format
 
+    @property
+    @abc.abstractmethod
+    def root_slug(self):
+        pass
+
     @abc.abstractmethod
     def exists(self):
         pass

--- a/bsb/topology/partition.py
+++ b/bsb/topology/partition.py
@@ -124,11 +124,6 @@ class Voxels(Partition, classmap_entry="voxels"):
         return self.voxels.get_voxelset()
 
     def to_chunks(self, chunk_size):
-        print(
-            "Thalamus as",
-            len(self.voxelset.snap_to_grid(chunk_size, unique=True)),
-            "chunks",
-        )
         return self.voxelset.snap_to_grid(chunk_size, unique=True)
 
     def chunk_to_voxels(self, chunk):

--- a/docs/cli/commands.rst
+++ b/docs/cli/commands.rst
@@ -10,6 +10,8 @@ List of commands
 Every command starts with: ``bsb [OPTIONS]``, where ``[OPTIONS]`` can
 be any combination of :doc:`BSB options </cli/options>`.
 
+.. _bsb_new:
+
 Create a project
 ================
 
@@ -22,6 +24,8 @@ project settings.
 
 * ``project-name``: Name of the project, and of the directory that will be created for it.
 * ``parent-folder``: Filesystem location where the project folder will be created.
+
+.. _bsb_make_config:
 
 Create a configuration
 ======================
@@ -40,6 +44,8 @@ template.
 * ``output.json``: Filename to be created.
 * ``--path``: Give additional paths to be searched for the template here.
 
+.. _bsb_compile:
+
 Compiling a network
 ===================
 
@@ -56,6 +62,8 @@ specified, the project default is used.
 * ``-o``, ``--output``: Output the result to a specific file. If omitted the value from
   the configuration, the project default, or a timestamped filename are used.
 
+.. _bsb_simulate:
+
 Run a simulation
 ================
 
@@ -67,6 +75,8 @@ Run a simulation from a compiled network architecture.
 
 * ``path/to/netw.hdf5``: Path to the network file.
 * ``sim-name``: Name of the simulation.
+
+.. _bsb_cache:
 
 Check the global cache
 ======================

--- a/docs/config/nodes.rst
+++ b/docs/config/nodes.rst
@@ -32,25 +32,14 @@ This node class describes the following configuration:
     }
   }
 
-The ``@config.node`` decorator takes the ordinary class and injects the logic it needs to
-fulfill the tasks of a configuration node. Whenever a node of this type is used in the
-configuration an instance of the node class is created and some work needs to happen:
-
-* The parsed configuration dictionary needs to be cast into an instance of the node class.
-* The configuration attributes of this node class and its parents need to be collected.
-* The attributes on this instance need to be initialized with a default value or ``None``.
-* The keys that are present in the configuration dictionary need to be transferred to the
-  node instance and converted to the specified type (the default type is ``str``)
-
 Dynamic nodes
 =============
 
 Dynamic nodes are those whose node class is configurable from inside the configuration
 node itself. This is done through the use of the ``@dynamic`` decorator instead of the
-node decorator. This will automatically create a required ``class`` attribute.
+node decorator. This will automatically create a required ``cls`` attribute.
 
-The value that is given to this class attribute will be used to import a class to
-instantiate the node:
+The value that is given to this attribute will be used to load the class of the node:
 
 .. code-block:: python
 
@@ -69,7 +58,7 @@ And in the configuration:
   }
 
 This would import the ``bsb.placement`` module and use its ``LayeredRandomWalk`` class to
-decorate the node.
+further process the node.
 
 .. note::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,7 @@ and explicit code understandable and reusable by your peers.
    usage/installation
    usage/top-level-guide
    usage/getting-started
+   usage/projects
 
 .. toctree::
    :maxdepth: 2

--- a/docs/usage/projects.rst
+++ b/docs/usage/projects.rst
@@ -1,0 +1,111 @@
+########
+Projects
+########
+
+Projects help you keep your models organized, safe, and neat! A project is a folder
+containing:
+
+* The ``pyproject.toml`` Python project settings file:
+  This file uses the TOML syntax to set configuration values for the BSB and any other
+  python tools your project uses.
+
+* One or more configuration files.
+
+* One or more network files.
+
+* Your component code.
+
+You can create projects using the :ref:`bsb.new <bsb_new>` command.
+
+Settings
+========
+
+Project settings are contained in the ``pyproject.toml`` file.
+
+* ``[tools.bsb]``: The root configuration section:
+  You can set the values of any :doc:`/cli/options` here.
+
+  * ``[tools.bsb.links]``: Contains the :ref:`file link <file_link>` definitions.
+
+  * ``[tools.bsb.links."my_network.hdf5"]``: Storage specific file links
+    In this example for a storage object called "my_network.hdf5"
+
+.. code-block:: toml
+
+  [tools.bsb]
+  verbosity = 3
+
+  [tools.bsb.links]
+  morpho = [ "sys", "morphologies.hdf5", "newer",]
+  config = "auto"
+
+  [tools.bsb.links."thalamus.hdf5"]
+  config = [ "sys", "thalamus.json", "always",]
+
+.. _file_link:
+
+File links
+==========
+
+Storage objects can keep copies of configuration and morphologies. These copies might
+become outdated during development. To automatically update it, you can specify file
+links.
+
+It is recommended that you only specify links for models that you are actively developing,
+to avoid overwriting and losing any unique configs or morphologies of a model.
+
+Config links
+------------
+
+Configuration links (``config =``) can be either *fixed* or *automatic*. Fixed config
+links will always overwrite the configuration of the model with the contents of the file,
+if it exists. Automatic config links do the same, but keep track of the path of the last
+saved config file, and stay linked with that file.
+
+Syntax
+------
+
+The first argument is the *provider* of the link: ``sys`` for the filesystem (your folder)
+``fs`` for the file store of the storage engine (storage engines may have their own way of
+storing files). The second argument is the path to the file, and the third argument is
+when to update, but is unused! For automatic config links you can simply pass the
+``"auto"`` string.
+
+.. note::
+
+  Links in ``tools.bsb.links`` are active for all models in your project! It's better to
+  specify them on a per model basis using the ``tools.bsb.links."my_model_name.hdf5"``
+  section.
+
+
+Component code
+==============
+
+It's best practice to keep all of your component code in a subfolder with the same name as
+your model. For example, if you're modelling the cerebellum, create a folder called
+``cerebellum``. Inside place an ``__init__.py`` file, so that Python can import code from
+it. Then you best subdivide your code based on component type, e.g. keep placement
+strategies in a file called ``placement.py``. That way, your placement components are
+available in your model as ``cerebellum.placement.MyComponent``. It will also make it
+easy to distribute your code as a package!
+
+Version control
+===============
+
+An often overlooked aspect is version control! Version control helps you track every
+change you make as a version of your code, backs up your code, and lets you switch between
+versions. The ``git`` protocol is currently the most popular version control, combined
+with providers like GitHub or GitLab.
+
+.. code-block:: diff
+
+  - This was my previous version
+  + This is my new version
+  This line was not affected
+
+This example shows how version control can track every change you make, to undo work, to
+try experimental changes, or to work on multiple conflicting features. Every change can be
+stored as a version, and backed up in the cloud.
+
+Projects come with a ``.gitignore`` file, where you can exclude files from being backed
+up. Cloud providers won't let neuroscientists upload 100GB network files |:innocent:|


### PR DESCRIPTION
## Describe the work done

* Added an `"auto"` option for config links, which will store and load the path of the config that was serialized, if it exists.
* Created a subcategory in `pyproject.toml` per network file, so that per file config links can be added.

## Tasks

* ~[ ] Added tests~
  * Test entry points into config
* [x] Updated documentation
  * Document the linking system
* [x] Change default project settings