### PR TITLE
Factored out a public API for the AllenStructureLoader

### DIFF
--- a/bsb/__init__.py
+++ b/bsb/__init__.py
@@ -8,5 +8,13 @@ try:
 except AttributeError:
     functools.cache = functools.lru_cache
 
+    def _register(self, cls, method=None):
+        if hasattr(cls, "__func__"):
+            setattr(cls, "__annotations__", cls.__func__.__annotations__)
+        return self.dispatcher.register(cls, func=method)
+
+    functools.singledispatchmethod.register = _register
+
+
 from ._mpi import *
 from .reporting import report, warn

--- a/bsb/voxels.py
+++ b/bsb/voxels.py
@@ -731,7 +731,7 @@ class AllenStructureLoader(NrrdVoxelLoader, classmap_entry="allen"):
     @classmethod
     def get_structure_mask(cls, find):
         """
-        Return all the set of IDs that make up the requested Allen structure.
+        Return the set of IDs that make up the requested Allen structure.
 
         :param find: Acronym or ID of the Allen structure.
         :type find: Union[str, int]

--- a/bsb/voxels.py
+++ b/bsb/voxels.py
@@ -747,33 +747,30 @@ class AllenStructureLoader(NrrdVoxelLoader, classmap_entry="allen"):
         cls._visit_structure([struct], flatmask)
         return np.array([*values], dtype=int)
 
-    @functools.singledispatchmethod
     @classmethod
     def find_structure(cls, id):
         """
-        Find an Allen structure by ID
-        """
-        find = lambda x: x["id"] == id
-        try:
-            return cls._find_structure(find)
-        except NodeNotFoundError:
-            raise NodeNotFoundError(f"Could not find structure with id '{id}'") from None
+        Find an Allen structure by name, acronym or ID.
 
-    @find_structure.register
-    @classmethod
-    def _(cls, name: str):
+        :param id: Query for the name, acronym or ID of the Allen structure.
+        :type id: Union[str, int, float]
+        :returns: Allen structure node of the Allen ontology tree.
+        :rtype: dict
+        :raises: NodeNotFoundError
         """
-        Find an Allen structure by name
-        """
-        proc = lambda s: s.strip().lower()
-        _name = proc(name)
-        find = lambda x: proc(x["name"]) == _name or proc(x["acronym"]) == _name
+        if isinstance(id, str):
+            treat = lambda s: s.strip().lower()
+            _name = treat(name)
+            find = lambda x: treat(x["name"]) == _name or treat(x["acronym"]) == _name
+        elif isinstance(id, int) or isinstance(id, float):
+            id = int(id)
+            find = lambda x: x["id"] == id
+        else:
+            raise TypeError(f"Argument must be a string or a number. {type(id)} given.")
         try:
             return cls._find_structure(find)
         except NodeNotFoundError:
-            raise NodeNotFoundError(
-                f"Could not find structure with name '{name}'"
-            ) from None
+            raise NodeNotFoundError(f"Could not find structure '{id}'") from None
 
     @classmethod
     def _find_structure(cls, find):

--- a/bsb/voxels.py
+++ b/bsb/voxels.py
@@ -712,6 +712,15 @@ class AllenStructureLoader(NrrdVoxelLoader, classmap_entry="allen"):
 
     @classmethod
     def get_structure_mask_condition(cls, find):
+        """
+        Return a lambda that when applied to the mask data, returns a mask that delineates
+        the Allen structure.
+
+        :param find: Acronym or ID of the Allen structure.
+        :type find: Union[str, int]
+        :returns: Masking lambda
+        :rtype: function
+        """
         mask = cls.get_structure_mask(find)
         if len(mask) > 1:
             return lambda data: np.isin(data, mask)
@@ -721,6 +730,14 @@ class AllenStructureLoader(NrrdVoxelLoader, classmap_entry="allen"):
 
     @classmethod
     def get_structure_mask(cls, find):
+        """
+        Return all the set of IDs that make up the requested Allen structure.
+
+        :param find: Acronym or ID of the Allen structure.
+        :type find: Union[str, int]
+        :returns: Set of IDs
+        :rtype: numpy.ndarray
+        """
         struct = cls.find_structure(find)
         values = set()
 
@@ -733,6 +750,9 @@ class AllenStructureLoader(NrrdVoxelLoader, classmap_entry="allen"):
     @functools.singledispatchmethod
     @classmethod
     def find_structure(cls, id):
+        """
+        Find an Allen structure by ID
+        """
         find = lambda x: x["id"] == id
         try:
             return cls._find_structure(find)
@@ -742,6 +762,9 @@ class AllenStructureLoader(NrrdVoxelLoader, classmap_entry="allen"):
     @find_structure.register
     @classmethod
     def _(cls, name: str):
+        """
+        Find an Allen structure by name
+        """
         proc = lambda s: s.strip().lower()
         _name = proc(name)
         find = lambda x: proc(x["name"]) == _name or proc(x["acronym"]) == _name

--- a/bsb/voxels.py
+++ b/bsb/voxels.py
@@ -719,7 +719,7 @@ class AllenStructureLoader(NrrdVoxelLoader, classmap_entry="allen"):
         :param find: Acronym or ID of the Allen structure.
         :type find: Union[str, int]
         :returns: Masking lambda
-        :rtype: function
+        :rtype: Callable[numpy.ndarray]
         """
         mask = cls.get_structure_mask(find)
         if len(mask) > 1:

--- a/docs/usage/getting-started.rst
+++ b/docs/usage/getting-started.rst
@@ -27,7 +27,7 @@ Use the command below to create a new project directory and some starter files:
 .. code-block:: bash
 
   bsb new my_first_model --quickstart
-	cd my_first_model
+  cd my_first_model
 
 The project now contains a couple of important files:
 

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,6 @@ setuptools.setup(
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Operating System :: OS Independent",


### PR DESCRIPTION
## Describe the work done

The `AllenStructureLoader` class can now be used to find structures of the Allen Atlas, without configuring an instance for it.

## Tasks

* [X] Updated documentation
