### PR TITLE
Disabled `test_cell_type_shorthand` in parallel testing

### DIFF
--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -9,7 +9,7 @@ from bsb.config import from_json, Configuration
 from bsb.morphologies import Morphology, Branch
 from bsb.exceptions import *
 from bsb.storage.interfaces import StoredMorphology
-from test_setup import single_process_test
+from test_setup import skip_parallel
 
 
 def spoof(*names):
@@ -58,7 +58,9 @@ class TestSelectors(unittest.TestCase):
         ws = NameSelector(names=["*"])
         self.assertEqual(len(all), sum(map(ws.pick, all)), "wildcard should select all")
 
-    @single_process_test
+    # For some reason, under parallel conditions, likely due to the `morphologies.save`,
+    # we deadlock.
+    @skip_parallel
     def test_cell_type_shorthand(self):
         ct = CellType(spatial=dict(morphologies=[{"names": "*"}]))
         cfg = Configuration.default(

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -9,6 +9,7 @@ from bsb.config import from_json, Configuration
 from bsb.morphologies import Morphology, Branch
 from bsb.exceptions import *
 from bsb.storage.interfaces import StoredMorphology
+from test_setup import single_process_test
 
 
 def spoof(*names):
@@ -57,6 +58,7 @@ class TestSelectors(unittest.TestCase):
         ws = NameSelector(names=["*"])
         self.assertEqual(len(all), sum(map(ws.pick, all)), "wildcard should select all")
 
+    @single_process_test
     def test_cell_type_shorthand(self):
         ct = CellType(spatial=dict(morphologies=[{"names": "*"}]))
         cfg = Configuration.default(


### PR DESCRIPTION
## Describe the work done

Probably because of `morphologies.save` being executed at the same time, some of the nodes deadlocked.

## List which issues this resolves:

Fixes stochastic failure of tests on the storage engine testing.