### PR TITLE
Per voxel density calculations

### DIFF
--- a/bsb/particles.py
+++ b/bsb/particles.py
@@ -143,7 +143,8 @@ class ParticleSystem:
         for voxel, count in zip(self.voxels, voxel_counts):
             particle_type["placed"] = particle_type.get("placed", 0) + count
             placement_matrix = np.random.rand(count, self.dimensions)
-            for particle_position in placement_matrix:
+            for in_voxel_pos in placement_matrix:
+                particle_position = voxel.origin + in_voxel_pos * voxel.size
                 self.add_particle(radius, particle_position, type=particle_type)
 
     def _fill_global(self, particle_type):

--- a/bsb/particles.py
+++ b/bsb/particles.py
@@ -127,45 +127,39 @@ class ParticleSystem:
         self.particles = []
         for particle_type in self.particle_types:
             radius = particle_type["radius"]
-            placement_voxels = particle_type["voxels"]
-            if "count" in particle_type:
-                self._fill_by_count(particle_type)
-            elif "densities" in particle_type:
-                self._fill_by_densities(particle_type)
+            count = particle_type["count"]
+            if count.size == 1:
+                self._fill_global(particle_type)
             else:
-                raise Exception(
-                    "Define either a `count` or `densities` in all particle types."
-                )
+                self._fill_per_voxel(particle_type)
 
-    def _fill_by_densities(self, particle_type):
-        voxel_densities = particle_type["densities"]
+    def _fill_per_voxel(self, particle_type):
+        voxel_counts = particle_type["count"]
         radius = particle_type["radius"]
-        if len(voxel_densities) != len(self.voxels):
+        if len(voxel_counts) != len(self.voxels):
             raise Exception(
-                f"Voxel density mismatch. Given {len(voxel_densities) } expected {len(self.voxels)}"
+                f"Particle system voxel mismatch. Given {len(voxel_counts)} expected {len(self.voxels)}"
             )
-        for voxel, density in zip(self.voxels, voxel_densities):
-            density = density[0]
-            volume = np.product(voxel.size)
-            particle_count = int(volume * density)
-            placement_matrix = np.random.rand(particle_count, self.dimensions)
+        for voxel, count in zip(self.voxels, voxel_counts):
+            particle_type["placed"] = particle_type.get("placed", 0) + count
+            placement_matrix = np.random.rand(count, self.dimensions)
             for particle_position in placement_matrix:
                 self.add_particle(radius, particle_position, type=particle_type)
 
-    def _fill_by_count(self, particle_type):
-        particle_count = particle_type["count"]
+    def _fill_global(self, particle_type):
+        particle_count = int(particle_type["count"])
+        particle_type["placed"] = particle_type.get("placed", 0) + particle_count
+        radius = particle_type["radius"]
         # Generate a matrix with random positions for the particles
         # Add an extra dimension to determine in which voxels to place the particles
         placement_matrix = np.random.rand(particle_count, self.dimensions + 1)
         # Generate each particle
-        for positions in placement_matrix:
+        for row in placement_matrix:
             # Determine the voxel to be placed in.
-            particle_voxel_id = int(positions[0] * len(placement_voxels))
-            particle_voxel = self.voxels[placement_voxels[particle_voxel_id]]
+            voxel_id = int(row[0] * len(self.voxels))
+            voxel = self.voxels[voxel_id]
             # Translate the particle into the voxel based on the remaining dimensions
-            particle_position = (
-                particle_voxel.origin + positions[1:] * particle_voxel.size
-            )
+            particle_position = voxel.origin + row[1:] * voxel.size
             # Store the particle object
             self.add_particle(radius, particle_position, type=particle_type)
 

--- a/bsb/placement/indicator.py
+++ b/bsb/placement/indicator.py
@@ -67,6 +67,7 @@ class PlacementIndications:
     count = config.attr(type=int)
     geometry = config.dict(type=types.any())
     morphologies = config.list(type=MorphologySelector)
+    voxel_density_key = config.attr(type=str)
 
 
 class _Noner:

--- a/bsb/placement/indicator.py
+++ b/bsb/placement/indicator.py
@@ -67,7 +67,7 @@ class PlacementIndications:
     count = config.attr(type=int)
     geometry = config.dict(type=types.any())
     morphologies = config.list(type=MorphologySelector)
-    voxel_density_key = config.attr(type=str)
+    density_key = config.attr(type=str)
 
 
 class _Noner:
@@ -107,15 +107,18 @@ class PlacementIndicator:
             )
         return ind
 
-    def guess(self, chunk=None):
+    def guess(self, chunk=None, voxels=None):
         count = self.indication("count")
         density = self.indication("density")
+        density_key = self.indication("density_key")
         planar_density = self.indication("planar_density")
         relative_to = self.indication("relative_to")
         density_ratio = self.indication("density_ratio")
         count_ratio = self.indication("count_ratio")
         if count is not None:
             estimate = self._estim_for_chunk(chunk, count)
+        if density_key is not None:
+            pass
         if density is not None:
             estimate = self._density_to_estim(density, chunk)
         if planar_density is not None:
@@ -145,7 +148,8 @@ class PlacementIndicator:
                     )
                 else:
                     raise PlacementRelationError(
-                        "%cell_type.name% requires relation %relation.name% to specify density information.",
+                        "%cell_type.name% requires relation %relation.name%"
+                        + "to specify density information.",
                         self.cell_type,
                         relation,
                     )
@@ -153,14 +157,25 @@ class PlacementIndicator:
                 raise PlacementError(
                     "Relation specified but no ratio indications provided."
                 )
+        if density_key is not None:
+            if voxels is None:
+                raise Exception("Can't guess voxel density without a voxelset.")
+            elif density_key in voxels.data_keys:
+                estimate = self._estim_for_voxels(voxels, density_key)
+            else:
+                raise RuntimeError(f"No voxel density data '{density_key}' found.")
         try:
-            # 1.2 cells == 0.8 probability for 1, 0.2 probability for 2
-            return int(np.floor(estimate) + (np.random.rand() < estimate % 1))
+            estimate = np.array(estimate)
         except NameError:
-            # If `estimate` is undefined after all this then there were no indicators.
+            # If `estimate` is undefined after all this then error out.
             raise IndicatorError(
-                f"No configuration indicators found for the number of '{self._cell_type.name}' in '{self._strat.name}'"
+                "No configuration indicators found for the number of"
+                + f"'{self._cell_type.name}' in '{self._strat.name}'"
             )
+        # 1.2 cells == 0.8 probability for 1, 0.2 probability for 2
+        return (
+            np.floor(estimate) + (np.random.rand(estimate.size) < estimate % 1)
+        ).astype(int)
 
     def _density_to_estim(self, density, chunk=None):
         return sum(p.volume(chunk) * density for p in self._strat.partitions)
@@ -176,3 +191,8 @@ class PlacementIndicator:
         chunk_volume = sum(p.volume(chunk) for p in self._strat.partitions)
         total_volume = sum(p.volume() for p in self._strat.partitions)
         return count * chunk_volume / total_volume
+
+    def _estim_for_voxels(self, voxels, key):
+        return voxels.get_data(key).ravel() * np.product(
+            voxels.get_size_matrix(copy=False), axis=1
+        )

--- a/bsb/placement/particle.py
+++ b/bsb/placement/particle.py
@@ -80,7 +80,6 @@ class ParticlePlacement(PlacementStrategy, _VoxelBasedParticleSystem):
         if len(colliding) > 0:
             system.solve_collisions()
             if self.prune:
-
                 number_pruned, pruned_per_type = system.prune(
                     at_risk_particles=system.displaced_particles
                 )

--- a/bsb/placement/particle.py
+++ b/bsb/placement/particle.py
@@ -7,9 +7,8 @@ from .. import config
 import itertools, numpy as np
 
 
-@config.node
-class RandomPlacement(PlacementStrategy):
-    def place(self, chunk, indicators):
+class _VoxelBasedParticleSystem:
+    def _fill_system(self, chunk, indicators):
         voxels = VoxelSet.concatenate(
             *(p.chunk_to_voxels(chunk) for p in self.partitions)
         )
@@ -20,14 +19,17 @@ class RandomPlacement(PlacementStrategy):
                 # Place particles in all voxels
                 "voxels": list(range(len(voxels))),
                 "radius": indicator.get_radius(),
-                "count": int(indicator.guess(chunk)),
+                # Indicator guesses either a global value, or a per voxel value.
+                "count": indicator.guess(chunk, voxels),
             }
             for name, indicator in indicators.items()
         ]
         # Create and fill the particle system.
         system = ParticleSystem(track_displaced=True, scaffold=self.scaffold)
         system.fill(voxels, particles)
+        return system
 
+    def _extract_system(self, system, chunk, indicators):
         if len(system.particles) == 0:
             return
 
@@ -44,58 +46,41 @@ class RandomPlacement(PlacementStrategy):
 
 
 @config.node
-class ParticlePlacement(PlacementStrategy):
+class RandomPlacement(_VoxelBasedParticleSystem, PlacementStrategy):
+    def place(self, chunk, indicators):
+        system = self._fill_system(chunk, indicators)
+        self._extract_system(system, chunk, indicators)
+
+
+@config.node
+class ParticlePlacement(_VoxelBasedParticleSystem, PlacementStrategy):
     prune = config.attr(type=bool, default=True)
     bounded = config.attr(type=bool, default=False)
     restrict = config.attr(type=dict)
 
     def place(self, chunk, indicators):
-        voxels = VoxelSet.concatenate(
-            *(p.chunk_to_voxels(chunk) for p in self.partitions)
-        )
-        density_key = indicators["test_cell"].indication("voxel_density_key")
-        # Define the particles for the particle system.
-        particles = [
-            {
-                "name": name,
-                # Place particles in all voxels
-                "voxels": list(range(len(voxels))),
-                "radius": indicator.get_radius(),
-                "densities": voxels.get_data(density_key),
-            }
-            for name, indicator in indicators.items()
-        ]
-        # Create and fill the particle system.
-        system = ParticleSystem(track_displaced=True, scaffold=self.scaffold)
-        system.fill(voxels, particles)
-
+        system = self._fill_system(chunk, indicators)
         if len(system.particles) == 0:
             return
-
         # Find the set of colliding particles
         colliding = system.find_colliding_particles()
         if len(colliding) > 0:
             system.solve_collisions()
             if self.prune:
+
                 number_pruned, pruned_per_type = system.prune(
                     at_risk_particles=system.displaced_particles
                 )
                 for name, indicator in indicators.items():
                     pruned = pruned_per_type[name]
-                    total = indicator.guess(chunk)
+                    total = [
+                        pt.get("placed", None)
+                        for pt in system.particle_types
+                        if pt["name"] == name
+                    ][0]
                     if not total:
                         pct = 0
                     else:
                         pct = int((pruned / total) * 100)
                     report(f"{pruned} {name} ({pct}%) cells pruned.")
-
-        for pt in system.particle_types:
-            cell_type = self.scaffold.cell_types[pt["name"]]
-            indicator = indicators[pt["name"]]
-            particle_positions = [p.position for p in system.particles if p.type is pt]
-            if len(particle_positions) == 0:
-                continue
-            positions = np.empty((len(particle_positions), 3))
-            positions[:] = particle_positions
-            report(f"Placing {len(positions)} {cell_type.name} in {chunk}", level=3)
-            self.place_cells(indicator, positions, chunk)
+        self._extract_system(system, chunk, indicators)

--- a/bsb/placement/particle.py
+++ b/bsb/placement/particle.py
@@ -53,6 +53,7 @@ class ParticlePlacement(PlacementStrategy):
         voxels = VoxelSet.concatenate(
             *(p.chunk_to_voxels(chunk) for p in self.partitions)
         )
+        density_key = indicators["test_cell"].indication("voxel_density_key")
         # Define the particles for the particle system.
         particles = [
             {
@@ -60,7 +61,7 @@ class ParticlePlacement(PlacementStrategy):
                 # Place particles in all voxels
                 "voxels": list(range(len(voxels))),
                 "radius": indicator.get_radius(),
-                "count": int(indicator.guess(chunk)),
+                "densities": voxels.get_data(density_key),
             }
             for name, indicator in indicators.items()
         ]

--- a/bsb/placement/particle.py
+++ b/bsb/placement/particle.py
@@ -50,14 +50,23 @@ class _VoxelBasedParticleSystem:
 
 
 @config.node
-class RandomPlacement(_VoxelBasedParticleSystem, PlacementStrategy):
+class RandomPlacement(PlacementStrategy, _VoxelBasedParticleSystem):
+    """
+    Place cells in random positions.
+    """
+
     def place(self, chunk, indicators):
         system = self._fill_system(chunk, indicators)
         self._extract_system(system, chunk, indicators)
 
 
 @config.node
-class ParticlePlacement(_VoxelBasedParticleSystem, PlacementStrategy):
+class ParticlePlacement(PlacementStrategy, _VoxelBasedParticleSystem):
+    """
+    Place cells in random positions, then have them repel each other until there is no
+    overlap.
+    """
+
     prune = config.attr(type=bool, default=True)
     bounded = config.attr(type=bool, default=False)
     restrict = config.attr(type=dict)

--- a/bsb/placement/particle.py
+++ b/bsb/placement/particle.py
@@ -8,6 +8,10 @@ import itertools, numpy as np
 
 
 class _VoxelBasedParticleSystem:
+    """
+    Internal mixin for particle system placement strategies
+    """
+
     def _fill_system(self, chunk, indicators):
         voxels = VoxelSet.concatenate(
             *(p.chunk_to_voxels(chunk) for p in self.partitions)

--- a/bsb/topology/__init__.py
+++ b/bsb/topology/__init__.py
@@ -21,7 +21,6 @@ def create_topology(regions):
         topology = roots[0]
     else:
         topology = Region(cls="group", partitions=regions, name="topology")
-        topology._partitions = regions
     return topology
 
 

--- a/bsb/voxels.py
+++ b/bsb/voxels.py
@@ -270,6 +270,10 @@ class VoxelSet:
         return self.get_data()
 
     @property
+    def data_keys(self):
+        return self._data.keys
+
+    @property
     def raw(self):
         return self.get_raw()
 

--- a/bsb/voxels.py
+++ b/bsb/voxels.py
@@ -734,8 +734,8 @@ class AllenStructureLoader(NrrdVoxelLoader, classmap_entry="allen"):
 
     @classmethod
     def get_structure_mask(cls, find):
-        mask_data, _ = nrrd.read(self._dl_mask())
-        return self.get_structure_mask_condition(find)(mask_data)
+        mask_data, _ = nrrd.read(cls._dl_mask())
+        return cls.get_structure_mask_condition(find)(mask_data)
 
     @classmethod
     def get_structure_idset(cls, find):
@@ -769,8 +769,8 @@ class AllenStructureLoader(NrrdVoxelLoader, classmap_entry="allen"):
         """
         if isinstance(id, str):
             treat = lambda s: s.strip().lower()
-            _name = treat(name)
-            find = lambda x: treat(x["name"]) == _name or treat(x["acronym"]) == _name
+            name = treat(id)
+            find = lambda x: treat(x["name"]) == name or treat(x["acronym"]) == name
         elif isinstance(id, int) or isinstance(id, float):
             id = int(id)
             find = lambda x: x["id"] == id

--- a/docs/bsb/bsb.placement.rst
+++ b/docs/bsb/bsb.placement.rst
@@ -10,7 +10,6 @@ bsb.placement.arrays module
 .. automodule:: bsb.placement.arrays
    :members:
    :undoc-members:
-   :show-inheritance:
 
 bsb.placement.indicator module
 ------------------------------
@@ -18,7 +17,6 @@ bsb.placement.indicator module
 .. automodule:: bsb.placement.indicator
    :members:
    :undoc-members:
-   :show-inheritance:
 
 bsb.placement.particle module
 -----------------------------
@@ -26,7 +24,6 @@ bsb.placement.particle module
 .. automodule:: bsb.placement.particle
    :members:
    :undoc-members:
-   :show-inheritance:
 
 bsb.placement.satellite module
 ------------------------------
@@ -34,7 +31,6 @@ bsb.placement.satellite module
 .. automodule:: bsb.placement.satellite
    :members:
    :undoc-members:
-   :show-inheritance:
 
 bsb.placement.strategy module
 -----------------------------
@@ -42,7 +38,6 @@ bsb.placement.strategy module
 .. automodule:: bsb.placement.strategy
    :members:
    :undoc-members:
-   :show-inheritance:
 
 Module contents
 ---------------
@@ -50,4 +45,3 @@ Module contents
 .. automodule:: bsb.placement
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/config/reference.rst
+++ b/docs/config/reference.rst
@@ -66,7 +66,24 @@ Cell types
 
 * :guilabel:`spatial`: Node for spatial information about the cell.
 
-  * :guilabel:`radius`: Radius of the indicative cell soma (μm).
+  * :guilabel:`radius`: Radius of the indicative cell soma (``μm``).
+
+  * :guilabel:`count`: Fixed number of cells to place.
+
+  * :guilabel:`density`: Volumetric density of cells (``1/(μm^3)``)
+
+  * :guilabel:`planar_density`: Planar density of cells (``1/(μm^2)``)
+
+  * :guilabel:`density_key`: Key of the :ref:`data column <data-columns>` that holds the
+    per voxel density information when this cell type is placed in a :ref:`voxel partition
+    <voxel-partition>`.
+
+  * :guilabel:`relative_to`: Reference to another cell type whose spatial information
+    determines this cell type's number.
+
+  * :guilabel:`density_ratio`: Ratio of densities to maintain with the related cell type.
+
+  * :guilabel:`count_ratio`: Ratio of counts to maintain with the related cell type.
 
   * :guilabel:`geometry`:
     Node for geometric information about the cell. This node may contain arbitrary keys

--- a/docs/topology/partitions.rst
+++ b/docs/topology/partitions.rst
@@ -2,6 +2,8 @@
 Partitions
 ##########
 
+.. _voxel-partition:
+
 ======
 Voxels
 ======
@@ -155,6 +157,8 @@ appear in the :guilabel:`sources` attribute:
         # `data[:, 1]` and `type3` in `data[:, 2]`.
         print(vs.data.shape)
         partition = Voxels(voxels=loader)
+
+.. _data-columns:
 
 .. rubric:: Tagging the data columns with keys
 

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -7,6 +7,7 @@ from bsb.core import Scaffold
 from bsb.config import Configuration, from_json
 from bsb.cell_types import CellType
 from bsb.topology import Region, Partition
+from bsb.voxels import VoxelSet, VoxelData
 from bsb.exceptions import *
 from bsb.storage import Chunk
 from bsb.placement import PlacementStrategy, RandomPlacement
@@ -33,11 +34,11 @@ class PlacementDud(PlacementStrategy):
 
 def single_layer_placement(offset=[0.0, 0.0, 0.0]):
     network = Scaffold()
+    network.regions["dud_region"] = reg = Region(
+        name="dud_region", offset=offset, partitions=[]
+    )
     network.partitions["dud_layer"] = part = Partition(
         name="dud_layer", thickness=120, region="dud_region"
-    )
-    network.regions["dud_region"] = reg = Region(
-        name="dud_region", offset=offset, partitions=[part]
     )
     dud_cell = CellType(name="dud", spatial={"count": 40, "radius": 2})
     network.cell_types["dud"] = dud_cell
@@ -115,9 +116,6 @@ class TestIndicators(unittest.TestCase):
             with self.subTest(x=x, y=y, z=z):
                 guess = dud_ind.guess(_chunk(x, y, z))
                 self.assertEqual(0, guess)
-
-
-dud, network = single_layer_placement()
 
 
 class SchedulerBaseTest:
@@ -216,13 +214,74 @@ class TestSerialScheduler(unittest.TestCase, SchedulerBaseTest):
 class TestPlacementStrategies(unittest.TestCase):
     def test_random_placement(self):
         cfg = from_json(get_config("test_single.json"))
-        cfg.placement["test_placement"] = RandomPlacement(
-            name="test_placement",
-            cell_types=[cfg.cell_types.test_cell],
-            partitions=[cfg.partitions.test_layer],
-        )
         cfg.storage.root = "random_placement.hdf5"
         network = Scaffold(cfg)
+        cfg.placement["test_placement"] = dict(
+            cls="bsb.placement.RandomPlacement",
+            cell_types=["test_cell"],
+            partitions=["test_layer"],
+        )
         network.compile(clear=True)
         ps = network.get_placement_set("test_cell")
         self.assertEqual(40, len(ps), "fixed count random placement broken")
+
+
+class TestVoxelDensities(unittest.TestCase):
+    def test_particle_vd(self):
+        cfg = Configuration.default(
+            cell_types=dict(
+                test_cell=CellType(spatial=dict(radius=2, density=2, density_key="inhib"))
+            ),
+            regions=dict(test_region=dict()),
+            partitions=dict(test_part=dict(type="test", region="test_region")),
+            placement=dict(
+                voxel_density=dict(
+                    cls="bsb.placement.ParticlePlacement",
+                    partitions=["test_part"],
+                    cell_types=["test_cell"],
+                )
+            ),
+        )
+        network = Scaffold(cfg)
+        counts = network.placement.voxel_density.get_indicators()["test_cell"].guess(
+            chunk=Chunk([0, 0, 0], [100, 100, 100]),
+            voxels=network.partitions.test_part.vs,
+        )
+        self.assertEqual(4, len(counts), "should have vector of counts per voxel")
+        self.assertTrue(np.allclose([78, 16, 8, 27], counts, atol=1), "densities incorr")
+        network.compile()
+        ps = network.get_placement_set("test_cell")
+        self.assertGreater(len(ps), 90)
+        self.assertLess(len(ps), 130)
+
+
+class VoxelParticleTest(Partition, classmap_entry="test"):
+    vs = VoxelSet(
+        [
+            [0, 0, 0],
+            [0, 0, 1],
+            [0, 1, 0],
+            [0, 1, 1],
+        ],
+        25,
+        data=VoxelData(
+            np.array(
+                [
+                    [0.005, 0.003],
+                    [0.001, 0.004],
+                    [0.0005, 0.0055],
+                    [0.0017, 0.0033],
+                ]
+            ),
+            keys=["inhib", "excit"],
+        ),
+    )
+
+    def to_chunks(self, chunk_size):
+        return [Chunk([0, 0, 0], chunk_size)]
+
+    def chunk_to_voxels(self, chunk):
+        return self.vs
+
+    def layout(self, boundaries):
+        self.boundaries = boundaries

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -54,6 +54,9 @@ def single_layer_placement(offset=[0.0, 0.0, 0.0]):
     return dud, network
 
 
+dud, network = single_layer_placement()
+
+
 def _chunk(x, y, z):
     return Chunk((x, y, z), (100, 100, 100))
 
@@ -249,7 +252,7 @@ class TestVoxelDensities(unittest.TestCase):
         )
         self.assertEqual(4, len(counts), "should have vector of counts per voxel")
         self.assertTrue(np.allclose([78, 16, 8, 27], counts, atol=1), "densities incorr")
-        network.compile()
+        network.compile(clear=True)
         ps = network.get_placement_set("test_cell")
         self.assertGreater(len(ps), 90)
         self.assertLess(len(ps), 130)


### PR DESCRIPTION
## Describe the work done

Indicators have a new `density_key` field, and can now return either a single value or a set of values per voxel when `guess`ing the amount of cells to place. This way per voxel densities can be applied to any placement strategy. If a `density_key` is given, they'll try to look up any voxel data columns with that name and use it as a basis for their guesses.

The `RandomPlacement` and `ParticlePlacement` strategies adopt this and use the per voxel values to fill each voxel of the particle system with the right density

## List which issues this resolves:

closes #210 (for real this time)

## Tasks

* [x] Added tests
* [x] Updated documentation
