### PR TITLE
`voxel_size` of allen voxels is now readonly const

### DIFF
--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -954,12 +954,12 @@ class ConfigurationProperty(ConfigurationAttribute):
         return self.fget(instance)
 
     def __set__(self, instance, value):
-        try:
-            f = self.fset
-        except:
-            raise AttributeError("Can't set attribute") from None
+        if self.fset is None:
+            e = AttributeError(f"Can't set attribute '{self.attr_name}'")
+            e.node = self
+            raise e
         else:
-            return f(instance, value)
+            return self.fset(instance, value)
 
 
 def _collect_kv(n, d, k, v):

--- a/bsb/voxels.py
+++ b/bsb/voxels.py
@@ -674,6 +674,10 @@ class AllenStructureLoader(NrrdVoxelLoader, classmap_entry="allen"):
     )
 
     @config.property
+    def voxel_size(self):
+        return 25
+
+    @config.property
     def mask_only(self):
         return self.source is None and len(self.sources) == 0
 

--- a/docs/topology/partitions.rst
+++ b/docs/topology/partitions.rst
@@ -242,8 +242,7 @@ converted into a data column on the voxelset:
               "sources": [
                 "data/allen_gene_expression_25.nrrd"
               ],
-              "keys": ["expression"],
-              "voxel_size": 25
+              "keys": ["expression"]
             }
           }
         }
@@ -263,7 +262,6 @@ converted into a data column on the voxelset:
             "data/allen_gene_expression_25.nrrd",
           ],
           keys=["expression"],
-          voxel_size=25,
         )
         partition = Voxels(voxels=loader)
         print("Gene expression values per voxel:", partition.voxelset.expression)

--- a/examples/atlas/allen_structure.json
+++ b/examples/atlas/allen_structure.json
@@ -19,8 +19,7 @@
         "type": "allen",
         "struct_name": "DEC",
         "source": "my_cell_density.nrrd",
-        "data_keys": ["my_cell_density"],
-        "voxel_size": 25
+        "data_keys": ["my_cell_density"]
       }
     }
   },


### PR DESCRIPTION
## Describe the work done

The `AllenStructureLoader` now has `voxel_size` hard coded to 25, until #387 is fixed. closes #494 

## Tasks

* [X] Updated documentation
