### PR TITLE
Fixed Getting Started JSON and NEST installation instructions

### DIFF
--- a/docs/usage/getting-started.rst
+++ b/docs/usage/getting-started.rst
@@ -74,7 +74,7 @@ To get started, we'll change the ``brain_region`` into a ``stack``, and add a
 
   .. literalinclude:: getting-started.json
     :language: json
-    :lines: 7-25
+    :lines: 12-30
 
   .. literalinclude:: getting_started.py
     :language: python
@@ -97,7 +97,7 @@ created for them. In the simplest case you define a soma :guilabel:`radius` and
 
   .. literalinclude:: getting-started.json
     :language: json
-    :lines: 26-39
+    :lines: 31-44
 
   .. literalinclude:: getting_started.py
     :language: python
@@ -111,7 +111,7 @@ Placement
 
   .. literalinclude:: getting-started.json
     :language: json
-    :lines: 40-51
+    :lines: 45-56
 
   .. literalinclude:: getting_started.py
     :language: python
@@ -144,7 +144,7 @@ Connectivity
 
   .. literalinclude:: getting-started.json
     :language: json
-    :lines: 52-62
+    :lines: 57-67
 
   .. literalinclude:: getting_started.py
     :language: python

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -90,10 +90,11 @@ with a virtual environment activated.
 .. code-block:: bash
 
   sudo apt-get update && apt-get install -y openmpi-bin libopenmpi-dev
-  git clone git@github.com:dbbs-lab/nest-simulator
+  git clone https://github.com/dbbs-lab/nest-simulator
   cd nest-simulator
   mkdir build
   cd build
+  pip install cmake cython
   cmake .. \
     -Dwith-mpi=ON \
     -Dwith-python=3 \

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -48,6 +48,7 @@ The scaffold framework can be installed using ``pip``:
 
 .. code-block:: bash
 
+  sudo apt-get install -y libopenmpi-dev openmpi-bin
   pip install "bsb>=4.0.0a0"
 
 You can verify that the installation works with:

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -48,7 +48,7 @@ The scaffold framework can be installed using ``pip``:
 
 .. code-block:: bash
 
-  sudo apt-get update && apt-get install -y libopenmpi-dev openmpi-bin
+  sudo apt-get update && sudo apt-get install -y libopenmpi-dev openmpi-bin
   pip install "bsb>=4.0.0a0"
 
 You can verify that the installation works with:

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -48,7 +48,7 @@ The scaffold framework can be installed using ``pip``:
 
 .. code-block:: bash
 
-  sudo apt-get install -y libopenmpi-dev openmpi-bin
+  sudo apt-get update && apt-get install -y libopenmpi-dev openmpi-bin
   pip install "bsb>=4.0.0a0"
 
 You can verify that the installation works with:


### PR DESCRIPTION
## Describe the work done

* Fixed literalinclude lines (closes #500)
* Updated NEST install so users without SSH can run it, and install prerequisites (closes #502)
* Added MPI install instructions (closes #404)
