### PR TITLE
Prevent duplicate checks, while keeping forked PR checks

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   black:
-
+    if: github.event_name == ‘push’ || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   black:
-    if: github.event_name == ‘push’ || github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-
+    if: github.event_name == ‘push’ || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    if: github.event_name == ‘push’ || github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   check-documentation:
-
+    if: github.event_name == ‘push’ || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   check-documentation:
-    if: github.event_name == ‘push’ || github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Since 06d267924f2122d11ee565086f869ce15965f7be the CI would run twice under several conditions. This should be fixed now?
