### PR TITLE
Fixed fencing in the `mpilock` mock

### DIFF
--- a/bsb/services/mpilock.py
+++ b/bsb/services/mpilock.py
@@ -48,7 +48,7 @@ class MockedWindowController:
             rank = self._master
         fence = Fence(self._rank == rank)
         if self._rank == rank:
-            return _NoopLock()
+            return _NoopLock(handle=handle, fence=fence)
         elif handle:
             return _NoHandle()
         else:

--- a/bsb/unittest/engines.py
+++ b/bsb/unittest/engines.py
@@ -53,11 +53,9 @@ class TestStorage(RandomStorageFixture):
             len(ps.load_positions()),
             "Data not empty",
         )
-        with ps._engine._master_write() as fence:
-            fence.guard()
-            ps.append_data(Chunk((0, 0, 0), (100, 100, 100)), [0])
+        ps.append_data(Chunk((0, 0, 0), (100, 100, 100)), [0])
         self.assertEqual(
-            1,
+            MPI.Get_size(),
             len(ps.load_positions()),
             "Failure to setup `storage.renew()` test due to chunk reading error.",
         )


### PR DESCRIPTION
Some tests used the locking mechanism of the hdf5 engine. It's not (yet?) part of the spec, so the test was altered, but the bug was also fixed.