### PR TITLE
Chunk comparisons

### DIFF
--- a/bsb/storage/_chunks.py
+++ b/bsb/storage/_chunks.py
@@ -71,16 +71,16 @@ class Chunk(np.ndarray):
 
     @property
     def box(self):
-        return np.concatenate((self.ldc, self.mdc), dtype=float)
+        return np.array(np.concatenate((self.ldc, self.mdc)), copy=False)
 
     @property
     def ldc(self):
-        return (self._size * self).astype(float)
+        return np.array(self._size * self, copy=False)
 
     @property
     def mdc(self):
         # self._size * (self + 1) might overflow when this formula will not.
-        return (self._size * self + self._size).astype(float)
+        return np.array(self._size * self + self._size, copy=False)
 
     @classmethod
     def from_id(cls, id, size):

--- a/bsb/storage/_chunks.py
+++ b/bsb/storage/_chunks.py
@@ -35,6 +35,12 @@ class Chunk(np.ndarray):
     def __lt__(self, other):
         return self.id < other.id
 
+    def __ge__(self, other):
+        return self.id >= other.id
+
+    def __le__(self, other):
+        return self.id <= other.id
+
     def __hash__(self):
         return int(self.id)
 

--- a/bsb/storage/_chunks.py
+++ b/bsb/storage/_chunks.py
@@ -23,6 +23,18 @@ class Chunk(np.ndarray):
         if obj is not None:
             self._size = getattr(obj, "_size", None)
 
+    def __ne__(self, other):
+        return self.id != other.id
+
+    def __eq__(self, other):
+        return self.id == other.id
+
+    def __gt__(self, other):
+        return self.id > other.id
+
+    def __lt__(self, other):
+        return self.id < other.id
+
     def __hash__(self):
         return int(self.id)
 

--- a/bsb/storage/_chunks.py
+++ b/bsb/storage/_chunks.py
@@ -71,16 +71,16 @@ class Chunk(np.ndarray):
 
     @property
     def box(self):
-        return np.concatenate((self.ldc, self.mdc))
+        return np.concatenate((self.ldc, self.mdc), dtype=float)
 
     @property
     def ldc(self):
-        return self._size * self
+        return (self._size * self).astype(float)
 
     @property
     def mdc(self):
         # self._size * (self + 1) might overflow when this formula will not.
-        return self._size * self + self._size
+        return (self._size * self + self._size).astype(float)
 
     @classmethod
     def from_id(cls, id, size):

--- a/tests/test_chunks.py
+++ b/tests/test_chunks.py
@@ -52,3 +52,13 @@ class TestChunks(unittest.TestCase):
         self.assertEqual(
             pos.tolist(), pos2.tolist(), "PlacementSet loaded extraneous chunk data"
         )
+
+    def test_comp(self):
+        self.assertTrue(Chunk([0, 0, 0], None) == Chunk([0, 0, 0], None), "eq chunk fail")
+        self.assertFalse(Chunk([0, 0, 0], None) != Chunk([0, 0, 0], None), "ne chunkfail")
+        self.assertTrue(Chunk([0, 0, 1], None) > Chunk([0, 0, 0], None), "gt chunk fail")
+        self.assertTrue(Chunk([0, 1, 0], None) < Chunk([0, 0, 1], None), "lt chunk fail")
+        self.assertTrue(Chunk([0, 1, 1], None) >= Chunk([0, 1, 0], None), "ge chunk fail")
+        self.assertTrue(Chunk([0, 1, 1], None) >= Chunk([0, 1, 1], None), "ge chunk fail")
+        self.assertTrue(Chunk([0, 1, 1], None) <= Chunk([0, 1, 1], None), "le chunk fail")
+        self.assertTrue(Chunk([0, 1, 1], None) <= Chunk([0, 2, 1], None), "le chunk fail")


### PR DESCRIPTION
## Describe the work done

Chunks can now be compared to each other for equality and order. Order is done by comparing id, which means to flatten the coordinates. This could be improved to follow a Hilbert space filling curve, so that sorting Chunks yields SFC order.

* [X] Added tests
