### PR TITLE
Errors during pool exec lead to MPI_Abort, so skip EmptySelectionError

### DIFF
--- a/tests/test_distributors.py
+++ b/tests/test_distributors.py
@@ -12,6 +12,7 @@ from bsb.unittest import skip_parallel
 
 
 class TestMorphologyDistributor(unittest.TestCase):
+    @skip_parallel("Errors during parallel jobs cause MPI_Abort, untestable scenario")
     def test_empty_selection(self):
         cfg = Configuration.default(
             regions=dict(reg=dict(children=["a"])),

--- a/tests/test_distributors.py
+++ b/tests/test_distributors.py
@@ -12,7 +12,8 @@ from bsb.unittest import skip_parallel
 
 
 class TestMorphologyDistributor(unittest.TestCase):
-    @skip_parallel("Errors during parallel jobs cause MPI_Abort, untestable scenario")
+    @skip_parallel
+    # Errors during parallel jobs cause MPI_Abort, untestable scenario.
     def test_empty_selection(self):
         cfg = Configuration.default(
             regions=dict(reg=dict(children=["a"])),


### PR DESCRIPTION
## Describe the work done

Skip a test to prevent local confusing test failure. No idea why CI was unaffected?

## List which issues this resolves:

closes #539 