### PR TITLE
BSB now requires bsb-hdf5 version 0.2.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # 4.0.0 - Too much to list
 
+# 40.0.0a30
+
+* BSB now requires bsb-hdf5 v 0.2.5
+
 # 4.0.0a19
 
 * Removed the `voxels` property of the `Voxels` partition, instead the children ``nrrd``

--- a/bsb/__init__.py
+++ b/bsb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.0.0a29"
+__version__ = "4.0.0a30"
 
 import functools
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ toml==0.10.2
 morphio==3.3.2
 appdirs==1.4.4
 # Plugins
-bsb-hdf5==0.2.4
+bsb-hdf5==0.2.5

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 requires = [
-    "bsb-hdf5==0.2.4",
+    "bsb-hdf5==0.2.5",
     "h5py~=3.0",
     "numpy~=1.19",
     "scipy~=1.5",


### PR DESCRIPTION
Now BSB depends on bsb-hdf5 v 0.2.5 instead of v 0.2.4