### PR TITLE
Consistent use of fixture pattern and renamed path functions

### DIFF
--- a/bsb/unittest/__init__.py
+++ b/bsb/unittest/__init__.py
@@ -90,7 +90,7 @@ class NumpyTestCase:
         )
 
 
-def get_data(*paths):
+def get_data_path(*paths):
     return _os.path.abspath(
         _os.path.join(
             _os.path.dirname(__file__),
@@ -100,33 +100,15 @@ def get_data(*paths):
     )
 
 
-def get_config(file):
-    return _os.path.abspath(
-        _os.path.join(
-            _os.path.dirname(__file__),
-            "data",
-            "configs",
-            file + (".json" if not file.endswith(".json") else ""),
-        )
+def get_config_path(file):
+    return get_data_path(
+        "configs", file + (".json" if not file.endswith(".json") else "")
     )
 
 
-def get_morphology(file):
-    return _os.path.abspath(
-        _os.path.join(
-            _os.path.dirname(__file__),
-            "data",
-            "morphologies",
-            file,
-        )
-    )
+def get_morphology_path(file):
+    return get_data_path("morphologies", file)
 
 
-def get_all_morphologies(suffix=""):
-    yield from _glob.glob(
-        _os.path.abspath(
-            _os.path.join(
-                _os.path.dirname(__file__), "data", "morphologies", "*" + suffix
-            )
-        )
-    )
+def get_all_morphology_paths(suffix=""):
+    yield from _glob.glob(get_data_path("morphologies", "*" + suffix))

--- a/bsb/unittest/engines.py
+++ b/bsb/unittest/engines.py
@@ -7,6 +7,7 @@ from ..morphologies import Morphology, MorphologySet
 from ..storage import Storage, Chunk
 from . import (
     NumpyTestCase,
+    FixedPosConfigFixture,
     RandomStorageFixture,
     MPI,
     timeout,
@@ -31,21 +32,13 @@ class _ScaffoldDummy:
         return list(self.cfg.cell_types.values())
 
 
-class TestStorage(RandomStorageFixture):
-    def __init_subclass__(cls, root_factory=None, *, engine_name, **kwargs):
-        super().__init_subclass__(**kwargs)
-        cls._engine = engine_name
-        cls._rootf = root_factory
-
-    def random_storage(self):
-        return super().random_storage(root_factory=self._rootf, engine=self._engine)
-
+class TestStorage(RandomStorageFixture, engine_name=None):
     @timeout(10)
     def test_init(self):
         # Use the init function to instantiate a storage container to its initial
         # empty state. This test avoids the `Scaffold` object as instantiating it might
         # create or remove data by relying on `renew` or `init` in its constructor.
-        s = self.random_storage()
+        s = self.storage
         s.create()
         s.init(_ScaffoldDummy(cfg))
         # Test that `init` created the placement sets for each cell type
@@ -60,7 +53,7 @@ class TestStorage(RandomStorageFixture):
         # Use the renew mechanism to reinstantiate a storage container to its initial
         # empty state. This test avoids the `Scaffold` object as instantiating it might
         # create or remove data by relying on `renew` or `init` in its constructor.
-        s = self.random_storage()
+        s = self.storage
         s.create()
         self.assertTrue(s.exists())
         ps = s._PlacementSet.require(s._engine, cfg.cell_types.test_cell)
@@ -89,7 +82,7 @@ class TestStorage(RandomStorageFixture):
 
     @timeout(10)
     def test_move(self):
-        s = self.random_storage()
+        s = self.storage
         for _ in range(100):
             os = Storage(self._engine, s.root)
             s.move(s.root[:-5] + "e" + s.root[-5:])
@@ -99,14 +92,14 @@ class TestStorage(RandomStorageFixture):
     @timeout(10)
     def test_remove_create(self):
         for _ in range(100):
-            s = self.random_storage()
+            s = self.storage
             s.remove()
             self.assertFalse(s.exists(), f"{MPI.Get_rank()} still finds removed storage.")
             s.create()
             self.assertTrue(s.exists(), f"{MPI.Get_rank()} can't find new storage yet.")
 
     def test_active_config(self):
-        s = self.random_storage()
+        s = self.storage
         cfg_a = Configuration.default(regions=dict(a=dict(children=[])))
         cfg_b = Configuration.default(regions=dict(b=dict(children=[])))
         for _ in range(100):
@@ -118,7 +111,7 @@ class TestStorage(RandomStorageFixture):
             self.assertEqual(cfg_b.regions.keys(), expected, "stored cfg B missmatch")
 
     def test_eq(self):
-        s = self.random_storage()
+        s = self.storage
         s2 = self.random_storage()
         self.assertEqual(s, s, "Same storage should be equal")
         self.assertNotEqual(s, s2, "Diff storages should be unequal")
@@ -130,51 +123,17 @@ class TestStorage(RandomStorageFixture):
         self.assertNotEqual(s.morphologies, "hello", "weird comp should be unequal")
 
 
-class TestEngine(RandomStorageFixture):
-    def __init_subclass__(cls, root_factory=None, *, engine_name, **kwargs):
-        super().__init_subclass__(**kwargs)
-        cls._engine = engine_name
-        cls._rootf = root_factory
-
+class TestEngine(RandomStorageFixture, engine_name=None):
     def setUp(self):
-        self.network = self.random_storage(root_factory=self._rootf, engine=self._engine)
+        super().setUp()
+        self.network = Scaffold(storage=self.storage)
 
 
-class TestPlacementSet(RandomStorageFixture, NumpyTestCase):
-    def __init_subclass__(cls, root_factory=None, *, engine_name, **kwargs):
-        super().__init_subclass__(**kwargs)
-        cls._engine = engine_name
-        cls._rootf = root_factory
-
+class TestPlacementSet(
+    FixedPosConfigFixture, RandomStorageFixture, NumpyTestCase, engine_name=None
+):
     def setUp(self):
-        self.storage = self.random_storage(root_factory=self._rootf, engine=self._engine)
-        self.cfg = Configuration.default(
-            cell_types=dict(test_cell=dict(spatial=dict(radius=2, count=100))),
-            placement=dict(
-                ch4_c25=dict(
-                    strategy="bsb.placement.strategy.FixedPositions",
-                    partitions=[],
-                    cell_types=["test_cell"],
-                )
-            ),
-        )
-        self.chunk_size = cs = self.cfg.network.chunk_size
-        self.chunks = [
-            Chunk((0, 0, 0), cs),
-            Chunk((0, 0, 1), cs),
-            Chunk((1, 0, 0), cs),
-            Chunk((1, 0, 1), cs),
-        ]
-        self.cfg.placement.ch4_c25.positions = MPI.bcast(
-            np.vstack(
-                (
-                    np.random.random((25, 3)) * cs + [0, 0, 0],
-                    np.random.random((25, 3)) * cs + [0, 0, cs[2]],
-                    np.random.random((25, 3)) * cs + [cs[0], 0, 0],
-                    np.random.random((25, 3)) * cs + [cs[0], 0, cs[2]],
-                )
-            )
-        )
+        super().setUp()
         self.network = Scaffold(self.cfg, self.storage)
 
     def test_init(self):
@@ -346,16 +305,10 @@ class TestPlacementSet(RandomStorageFixture, NumpyTestCase):
         self.assertClose(pos_sort, pspos_sort, "expected fixed positions")
 
 
-class TestMorphologyRepository(NumpyTestCase, RandomStorageFixture):
-    def __init_subclass__(cls, root_factory=None, *, engine_name, **kwargs):
-        super().__init_subclass__(**kwargs)
-        cls._engine = engine_name
-        cls._rootf = root_factory
-
+class TestMorphologyRepository(NumpyTestCase, RandomStorageFixture, engine_name=None):
     def setUp(self):
-        self.mr = self.random_storage(
-            root_factory=self._rootf, engine=self._engine
-        ).morphologies
+        super().setUp()
+        self.mr = self.storage.morphologies
 
     @single_process_test
     def test_swc_saveload_eq(self):

--- a/bsb/unittest/engines.py
+++ b/bsb/unittest/engines.py
@@ -12,8 +12,8 @@ from . import (
     MPI,
     timeout,
     single_process_test,
-    get_all_morphologies,
-    get_morphology,
+    get_all_morphology_paths,
+    get_morphology_path,
 )
 import time
 import numpy as np
@@ -226,8 +226,8 @@ class TestPlacementSet(
         self.network.cell_types.test_cell.spatial.morphologies.append(
             dict(names=["test_cell_A", "test_cell_B"])
         )
-        mA = Morphology.from_swc(get_morphology("2branch.swc"))
-        mB = Morphology.from_swc(get_morphology("2comp.swc"))
+        mA = Morphology.from_swc(get_morphology_path("2branch.swc"))
+        mB = Morphology.from_swc(get_morphology_path("2comp.swc"))
         self.network.morphologies.save("test_cell_A", mA, overwrite=True)
         self.network.morphologies.save("test_cell_B", mB, overwrite=True)
         for i in range(10):
@@ -259,8 +259,8 @@ class TestPlacementSet(
         self.network.cell_types.test_cell.spatial.morphologies.append(
             dict(names=["test_cell_A", "test_cell_B"])
         )
-        mA = Morphology.from_swc(get_morphology("2branch.swc"))
-        mB = Morphology.from_swc(get_morphology("2comp.swc"))
+        mA = Morphology.from_swc(get_morphology_path("2branch.swc"))
+        mB = Morphology.from_swc(get_morphology_path("2comp.swc"))
         self.network.morphologies.save("test_cell_A", mA, overwrite=True)
         self.network.morphologies.save("test_cell_B", mB, overwrite=True)
         self.network.compile(clear=True)
@@ -277,8 +277,8 @@ class TestPlacementSet(
             dict(names=["test_cell_A", "test_cell_B"])
         )
         self.network.placement.ch4_c25.distribute.rotations = dict(strategy="random")
-        mA = Morphology.from_swc(get_morphology("2branch.swc"))
-        mB = Morphology.from_swc(get_morphology("2comp.swc"))
+        mA = Morphology.from_swc(get_morphology_path("2branch.swc"))
+        mB = Morphology.from_swc(get_morphology_path("2comp.swc"))
         self.network.morphologies.save("test_cell_A", mA, overwrite=True)
         self.network.morphologies.save("test_cell_B", mB, overwrite=True)
         self.network.compile(clear=True)
@@ -312,7 +312,7 @@ class TestMorphologyRepository(NumpyTestCase, RandomStorageFixture, engine_name=
 
     @single_process_test
     def test_swc_saveload_eq(self):
-        for path in get_all_morphologies(".swc"):
+        for path in get_all_morphology_paths(".swc"):
             with self.subTest(morpho=path.split("/")[-1]):
                 m = Morphology.from_swc(path)
                 self.mr.save("X", m, overwrite=True)
@@ -322,7 +322,7 @@ class TestMorphologyRepository(NumpyTestCase, RandomStorageFixture, engine_name=
 
     @single_process_test
     def test_swc_saveload(self):
-        for path in get_all_morphologies(".swc"):
+        for path in get_all_morphology_paths(".swc"):
             with self.subTest(morpho=path.split("/")[-1]):
                 m = Morphology.from_swc(path)
                 self.mr.save("X", m, overwrite=True)
@@ -346,7 +346,7 @@ class TestMorphologyRepository(NumpyTestCase, RandomStorageFixture, engine_name=
 
     @single_process_test
     def test_swc_ldc_mdc(self):
-        for path in get_all_morphologies(".swc"):
+        for path in get_all_morphology_paths(".swc"):
             with self.subTest(morpho=path.split("/")[-1]):
                 m = Morphology.from_swc(path)
                 self.mr.save("pc", m, overwrite=True)

--- a/tests/test_chunks.py
+++ b/tests/test_chunks.py
@@ -6,7 +6,7 @@ from bsb.core import Scaffold
 from bsb.config import from_json
 from bsb.storage import Chunk
 from bsb.exceptions import *
-from bsb.unittest import get_config, skip_parallel, timeout
+from bsb.unittest import get_config_path, skip_parallel, timeout
 
 
 class TestChunks(unittest.TestCase):
@@ -34,7 +34,7 @@ class TestChunks(unittest.TestCase):
     # basic chunk properties. For example uses `.place` directly.
     def test_single_chunk(self):
         # Test that specifying a single chunk only reads the data from that chunk
-        cfg = from_json(get_config("test_single"))
+        cfg = from_json(get_config_path("test_single"))
         self.network = network = Scaffold(cfg, clear=True)
         self.ps = ps = network.get_placement_set("test_cell")
         ps.load_chunk(Chunk((0, 0, 0), (100, 100, 100)))

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -4,10 +4,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 from bsb.core import Scaffold, from_hdf5
 from bsb.config import from_json
-from bsb.unittest import get_config
+from bsb.unittest import get_config_path
 
 
-single_neuron_config = get_config("test_single_neuron.json")
+single_neuron_config = get_config_path("test_single_neuron.json")
 
 
 class TestSingleTypeCompilation(unittest.TestCase):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -8,15 +8,10 @@ from bsb.config import from_json, Configuration, _attrs
 from bsb.config import types
 from bsb.exceptions import *
 from bsb.topology.region import RegionGroup
-from bsb.unittest import get_config
+from bsb.unittest import get_config_path
 
-
-def relative_to_tests_folder(path):
-    return os.path.join(os.path.dirname(__file__), path)
-
-
-minimal_config = get_config("test_minimal.json")
-full_config = get_config("test_full_v4.json")
+minimal_config = get_config_path("test_minimal.json")
+full_config = get_config_path("test_full_v4.json")
 
 
 @config.root

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,6 @@ from bsb.storage.interfaces import PlacementSet
 from bsb.config import Configuration
 from bsb import core
 from bsb.exceptions import *
-from bsb.unittest import get_config
 
 
 class TestCore(unittest.TestCase):

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -8,7 +8,6 @@ from bsb.config import from_json, Configuration
 from bsb.config.refs import Reference
 from bsb.config import types
 from bsb.exceptions import *
-from bsb.unittest import get_config
 from bsb.topology import Region, Partition
 
 

--- a/tests/test_morphologies.py
+++ b/tests/test_morphologies.py
@@ -7,7 +7,7 @@ from bsb.morphologies import Morphology, Branch, _Labels, MorphologySet
 from bsb.storage import Storage
 from bsb.storage.interfaces import StoredMorphology
 from bsb.exceptions import *
-from bsb.unittest import get_data, get_morphology_path, NumpyTestCase
+from bsb.unittest import get_morphology_path, NumpyTestCase
 from scipy.spatial.transform import Rotation
 
 

--- a/tests/test_morphologies.py
+++ b/tests/test_morphologies.py
@@ -7,13 +7,13 @@ from bsb.morphologies import Morphology, Branch, _Labels, MorphologySet
 from bsb.storage import Storage
 from bsb.storage.interfaces import StoredMorphology
 from bsb.exceptions import *
-from bsb.unittest import get_data, get_morphology, NumpyTestCase
+from bsb.unittest import get_data, get_morphology_path, NumpyTestCase
 from scipy.spatial.transform import Rotation
 
 
 class TestIO(NumpyTestCase, unittest.TestCase):
     def test_swc_2comp(self):
-        m = Morphology.from_swc(get_morphology("2comp.swc"))
+        m = Morphology.from_swc(get_morphology_path("2comp.swc"))
         self.assertEqual(2, len(m), "Expected 2 points on the morphology")
         self.assertEqual(1, len(m.roots), "Expected 1 root on the morphology")
         self.assertClose([1, 1], m.tags, "tags should be all soma")
@@ -21,12 +21,12 @@ class TestIO(NumpyTestCase, unittest.TestCase):
         self.assertEqual({0: set(), 1: {"soma"}}, m.labels.labels, "incorrect labelsets")
 
     def test_swc_2root(self):
-        m = Morphology.from_swc(get_morphology("2root.swc"))
+        m = Morphology.from_swc(get_morphology_path("2root.swc"))
         self.assertEqual(2, len(m), "Expected 2 points on the morphology")
         self.assertEqual(2, len(m.roots), "Expected 2 roots on the morphology")
 
     def test_swc_branch_filling(self):
-        m = Morphology.from_swc(get_morphology("3branch.swc"))
+        m = Morphology.from_swc(get_morphology_path("3branch.swc"))
         # SWC specifies child-parent edges, when translating that to branches, at branch
         # points some points need to be duplicated: there's 4 samples (SWC) and 2 child
         # branches -> 2 extra points == 6 points
@@ -36,7 +36,7 @@ class TestIO(NumpyTestCase, unittest.TestCase):
 
     def test_known(self):
         # TODO: Check the morphos visually with glover
-        m = Morphology.from_swc(get_morphology("PurkinjeCell.swc"))
+        m = Morphology.from_swc(get_morphology_path("PurkinjeCell.swc"))
         self.assertEqual(3834, len(m), "Amount of point on purkinje changed")
         self.assertEqual(459, len(m.branches), "Amount of branches on purkinje changed")
         self.assertEqual(
@@ -44,7 +44,7 @@ class TestIO(NumpyTestCase, unittest.TestCase):
             np.mean(m.points),
             "value of the universe, life and everything changed.",
         )
-        m = Morphology.from_file(get_morphology("GolgiCell.asc"))
+        m = Morphology.from_file(get_morphology_path("GolgiCell.asc"))
         self.assertEqual(5105, len(m), "Amount of point on purkinje changed")
         self.assertEqual(227, len(m.branches), "Amount of branches on purkinje changed")
         self.assertEqual(
@@ -54,8 +54,8 @@ class TestIO(NumpyTestCase, unittest.TestCase):
         )
 
     def test_shared_labels(self):
-        m = Morphology.from_swc(get_morphology("PurkinjeCell.swc"))
-        m2 = Morphology.from_swc(get_morphology("PurkinjeCell.swc"))
+        m = Morphology.from_swc(get_morphology_path("PurkinjeCell.swc"))
+        m2 = Morphology.from_swc(get_morphology_path("PurkinjeCell.swc"))
         l = m._shared._labels.labels
         self.assertIsNot(l, m2._shared._labels.label, "reload shares state")
         for b in m.branches:

--- a/tests/test_neuron.py
+++ b/tests/test_neuron.py
@@ -6,18 +6,18 @@ from bsb.core import Scaffold, from_hdf5
 from bsb.config import from_json
 from bsb.exceptions import *
 from bsb.services import MPI as mpi
-from bsb.unittest import get_config
+from bsb.unittest import get_config_path
 import unittest, numpy as np, h5py, importlib
 
 
-config = get_config("legacy_mouse_cerebellum_cortex.json")
-miniature_config = get_config("test_nrn_miniature.json")
-mf_grc_config = get_config("test_nrn_mf_granule.json")
-mf_gol_config = get_config("test_nrn_mf_golgi.json")
-aa_goc_config = get_config("test_nrn_aa_goc.json")
-aa_pc_config = get_config("test_nrn_aa_pc.json")
-grc_sc_config = get_config("test_nrn_grc_sc.json")
-sc_pc_config = get_config("test_nrn_sc_pc.json")
+config = get_config_path("legacy_mouse_cerebellum_cortex.json")
+miniature_config = get_config_path("test_nrn_miniature.json")
+mf_grc_config = get_config_path("test_nrn_mf_granule.json")
+mf_gol_config = get_config_path("test_nrn_mf_golgi.json")
+aa_goc_config = get_config_path("test_nrn_aa_goc.json")
+aa_pc_config = get_config_path("test_nrn_aa_pc.json")
+grc_sc_config = get_config_path("test_nrn_grc_sc.json")
+sc_pc_config = get_config_path("test_nrn_sc_pc.json")
 
 
 def neuron_installed():

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -5,11 +5,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 from bsb import config
 from bsb.config import from_json
 from bsb.exceptions import *
-from bsb.unittest import get_data
+from bsb.unittest import get_data_path
 
 
 def get_content(f):
-    with open(get_data("parser_tests", f), "r") as fh:
+    with open(get_data_path("parser_tests", f), "r") as fh:
         return fh.read()
 
 
@@ -49,7 +49,7 @@ class TestJsonRef(unittest.TestCase):
     def test_far_references(self):
         tree, meta = config.get_parser("json").parse(
             get_content("interdoc_refs.json"),
-            path=get_data("parser_tests", "interdoc_refs.json"),
+            path=get_data_path("parser_tests", "interdoc_refs.json"),
         )
         self.assertIn("was", tree["refs"]["far"])
         self.assertEqual("in another folder", tree["refs"]["far"]["was"])
@@ -58,13 +58,15 @@ class TestJsonRef(unittest.TestCase):
 
     def test_double_ref(self):
         tree, meta = config.get_parser("json").parse(
-            get_content("doubleref.json"), path=get_data("parser_tests", "doubleref.json")
+            get_content("doubleref.json"),
+            path=get_data_path("parser_tests", "doubleref.json"),
         )
 
     def test_ref_str(self):
         parser = config.get_parser("json")
         tree, meta = parser.parse(
-            get_content("doubleref.json"), path=get_data("parser_tests", "doubleref.json")
+            get_content("doubleref.json"),
+            path=get_data_path("parser_tests", "doubleref.json"),
         )
         self.assertTrue(str(parser.references[0]).startswith("<json ref '"))
         # Convert windows backslashes

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -12,7 +12,7 @@ from bsb.exceptions import *
 from bsb.storage import Chunk
 from bsb.placement import PlacementStrategy, RandomPlacement
 from bsb.services.pool import JobPool, FakeFuture, create_job_pool
-from bsb.unittest import get_config, timeout, RandomStorageFixture, NumpyTestCase
+from bsb.unittest import get_config_path, timeout, RandomStorageFixture, NumpyTestCase
 from time import sleep
 
 
@@ -213,7 +213,7 @@ class TestSerialScheduler(unittest.TestCase, SchedulerBaseTest):
 
 class TestPlacementStrategies(RandomStorageFixture, NumpyTestCase, unittest.TestCase):
     def test_random_placement(self):
-        cfg = from_json(get_config("test_single.json"))
+        cfg = from_json(get_config_path("test_single.json"))
         storage = self.random_storage(engine="hdf5")
         network = Scaffold(cfg, storage)
         cfg.placement["test_placement"] = dict(
@@ -257,7 +257,7 @@ class TestPlacementStrategies(RandomStorageFixture, NumpyTestCase, unittest.Test
 
     def test_parallel_arrays(self):
         storage = self.random_storage(engine="hdf5")
-        cfg = from_json(get_config("test_single.json"))
+        cfg = from_json(get_config_path("test_single.json"))
         network = Scaffold(cfg, storage)
         cfg.placement["test_placement"] = dict(
             strategy="bsb.placement.ParallelArrayPlacement",

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -7,14 +7,14 @@ from bsb.config import from_json
 from bsb.exceptions import *
 from bsb.storage import Storage, Chunk
 from bsb.storage import _util
-from bsb.unittest import get_config, timeout
+from bsb.unittest import get_config_path, timeout
 from bsb.services import MPI
 import pathlib
 
 
 class TestUtil(unittest.TestCase):
     def test_links(self):
-        cfg = from_json(get_config("test_single"))
+        cfg = from_json(get_config_path("test_single"))
         netw = Scaffold(cfg)
         # Needs more tests, these tests basically only test instantiation
         link = _util.link(netw.files, pathlib.Path.cwd(), "sys", "hellooo", "always")


### PR DESCRIPTION
## Describe the work done

Went over the `unittest` module so that all fixtures follow this pattern:

* They are composable mixin classes
* They set the fixture under `self` in `setUp` or `setUpClass`, eg the storage fixture sets `self.storage`. Requires one to know the attribute a fixture uses. 

Also renamed `get_data`, `get_config`, `get_morphology` and `get_all_morphologies` to `get_data_path`, ..., `get_all_morphology_paths` to reflect that they return the path and not the object.
