### PR TITLE
Added 'to_data_array' function

### DIFF
--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -709,7 +709,7 @@ class Morphology(SubTree):
                 encoding=None,
             )
 
-    def to_data_array(self):
+    def to_graph_array(self):
         """
         Create a SWC-like numpy array from a Morphology.
         :returns: a numpy array with columns storing the standard SWC attributes

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -714,9 +714,9 @@ class Morphology(SubTree):
         Create a SWC-like numpy array from a Morphology.
 
         .. warning::
-        
+
             Custom SWC tags (above 3) won't work and throw an error
-        
+
         :returns: a numpy array with columns storing the standard SWC attributes
         :rtype: numpy.ndarray
         """

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -712,12 +712,13 @@ class Morphology(SubTree):
     def to_graph_array(self):
         """
         Create a SWC-like numpy array from a Morphology.
+
+        .. warning::
+        
+            Custom SWC tags (above 3) won't work and throw an error
+        
         :returns: a numpy array with columns storing the standard SWC attributes
         :rtype: numpy.ndarray
-
-        -- warning::
-            Custom SWC labels don't work and throw an error
-
         """
         data = _morpho_to_swc(self)
         return data

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -713,6 +713,11 @@ class Morphology(SubTree):
         """
         Create a SWC-like numpy array from a Morphology.
         :returns: a numpy array with columns storing the standard SWC attributes
+        :rtype: numpy.ndarray
+
+        -- warning::
+            Custom SWC labels don't work and throw an error
+
         """
         data = _morpho_to_swc(self)
         return data

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -709,6 +709,14 @@ class Morphology(SubTree):
                 encoding=None,
             )
 
+    def to_data_array(self):
+        """
+        Create a SWC-like numpy array from a Morphology.
+        :returns: a numpy array with columns storing the standard SWC attributes
+        """
+        data = _morpho_to_swc(self)
+        return data
+
 
 def _copy_api(cls, wrap=lambda self: self):
     # Wraps functions so they are called with `self` wrapped in `wrap`


### PR DESCRIPTION
Wrapped the internal `_morpho_to_swc` function in a new `to_data_array` function that returns users a SWC-like `numpy` array from a given `Morphology`