### PR TITLE
Improved data key error message

### DIFF
--- a/bsb/config/parsers/json.py
+++ b/bsb/config/parsers/json.py
@@ -3,8 +3,9 @@ JSON parsing module. Built on top of the Python ``json`` module. Adds JSON impor
 references.
 """
 
-import json, os
-from ...exceptions import *
+import json
+import os
+from ...exceptions import JsonImportError, ConfigurationWarning, JsonReferenceError
 from ...reporting import warn
 from ._parser import Parser
 
@@ -29,7 +30,7 @@ class parsed_node:
         return carry
 
     def __str__(self):
-        return "<parsed config '{}'>".format(self.location())
+        return f"<parsed json config '{self}' at '{self.location()}'>"
 
     def __repr__(self):
         return super().__str__()
@@ -123,7 +124,9 @@ class json_imp(json_ref):
                         imported.merge(self.node[key])
                     else:
                         warn(
-                            f"Importkey '{key}' of {self} is ignored because the parent already contains a key '{key}' with value '{self.node[key]}'.",
+                            f"Importkey '{key}' of {self} is ignored because the parent"
+                            f" already contains a key '{key}'"
+                            f" with value '{self.node[key]}'.",
                             ConfigurationWarning,
                             stacklevel=3,
                         )

--- a/bsb/config/parsers/json.py
+++ b/bsb/config/parsers/json.py
@@ -30,7 +30,7 @@ class parsed_node:
         return carry
 
     def __str__(self):
-        return f"<parsed json config '{self}' at '{self.location()}'>"
+        return f"<parsed json config '{super().__str__()}' at '{self.location()}'>"
 
     def __repr__(self):
         return super().__str__()

--- a/bsb/exceptions.py
+++ b/bsb/exceptions.py
@@ -90,6 +90,7 @@ _t(
         ),
         PlacementError=_e(
             ChunkError=_e(),
+            PlacementRelationError=_e(),
             ContinuityError=_e(),
             PackingError=_e(),
         ),

--- a/bsb/placement/indicator.py
+++ b/bsb/placement/indicator.py
@@ -114,7 +114,20 @@ class PlacementIndicator:
             elif density_key in voxels.data_keys:
                 estimate = self._estim_for_voxels(voxels, density_key)
             else:
-                raise RuntimeError(f"No voxel density data '{density_key}' found.")
+                raise RuntimeError(
+                    f"No voxel density data column '{density_key}' found in any of the"
+                    " following partitions:"
+                    + "\n".join(
+                        f"* {p.name}: {', '.join(p.voxelset.data_keys)}"
+                        for p in self._strat.partitions
+                        if hasattr(p, "voxelset")
+                    )
+                    + "\n".join(
+                        f"* {p.name} contains no voxelsets"
+                        for p in self._strat.partitions
+                        if not hasattr(p, "voxelset")
+                    )
+                )
         try:
             estimate = np.array(estimate)
         except NameError:

--- a/bsb/placement/indicator.py
+++ b/bsb/placement/indicator.py
@@ -1,10 +1,8 @@
-from ..exceptions import *
+from ..exceptions import IndicatorError, PlacementRelationError, PlacementError
 from .. import config
 from ..config import refs, types
 from ..morphologies.selector import MorphologySelector
 import numpy as np
-import abc
-import re
 
 
 @config.node
@@ -54,7 +52,8 @@ class PlacementIndicator:
         ind = self.indication(attr)
         if ind is None:
             raise IndicatorError(
-                f"No configuration indicators found for the {attr} of '{self._cell_type.name}' in '{self._strat.name}'"
+                f"No configuration indicators found for the {attr}"
+                f" of '{self._cell_type.name}' in '{self._strat.name}'"
             )
         return ind
 
@@ -116,9 +115,18 @@ class PlacementIndicator:
             else:
                 raise RuntimeError(
                     f"No voxel density data column '{density_key}' found in any of the"
-                    " following partitions:"
+                    " following partitions:\n"
                     + "\n".join(
-                        f"* {p.name}: {', '.join(p.voxelset.data_keys)}"
+                        f"* {p.name}: "
+                        + (
+                            fstr
+                            if (
+                                fstr := ", ".join(
+                                    f"'{col}'" for col in p.voxelset.data_keys
+                                )
+                            )
+                            else "no data"
+                        )
                         for p in self._strat.partitions
                         if hasattr(p, "voxelset")
                     )

--- a/bsb/reporting.py
+++ b/bsb/reporting.py
@@ -1,4 +1,5 @@
 from .services import MPI
+from . import exceptions as _exc
 import functools
 import warnings
 import base64
@@ -9,6 +10,11 @@ import io
 _preamble = chr(240) + chr(80) + chr(85) + chr(248) + chr(228)
 _preamble_bar = chr(191) * 3
 _report_file = None
+
+
+for e in _exc.__dict__.values():
+    if isinstance(e, type) and issubclass(e, Warning):
+        warnings.simplefilter("always", e)
 
 
 def warning_on_one_line(message, category, filename, lineno, file=None, line=None):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -30,7 +30,9 @@ class TestJsonBasics(unittest.TestCase):
             tree["nest me hard"]["oh yea"],
             "Incorrectly parsed nested JSON",
         )
-        self.assertEqual("<parsed config '/list'>", str(tree["list"]))
+        self.assertEqual(
+            "<parsed json config '[1, 2, 3, 'waddup']' at '/list'>", str(tree["list"])
+        )
 
 
 class TestJsonRef(unittest.TestCase):


### PR DESCRIPTION
## Describe the work done

Configuring the keys across multiple entities can get tricky, so I improved the error message to show all available data and received commands. closes #602

@DianelaOB the error message now reads:

```
robin@TNG2019:~/git/issues$ bsb compile Declive.json --clear
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'data_keys' in {root}.partitions.granular_layer
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'data_keys' in {root}.partitions.purkinje_layer
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'data_keys' in {root}.partitions.b_molecular_layer
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'data_keys' in {root}.partitions.t_molecular_layer
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'dist_x' in {root}.cell_types.purkinje_cell.spatial
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'dist_z' in {root}.cell_types.purkinje_cell.spatial
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'restrict' in {root}.placement.molecular_layer_placement
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'divergence' in {root}.connectivity.golgi_to_glomerulus
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'convergence' in {root}.connectivity.golgi_to_glomerulus
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'tag_aa' in {root}.connectivity.granule_to_golgi
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'tag_pf' in {root}.connectivity.granule_to_golgi
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'aa_convergence' in {root}.connectivity.granule_to_golgi
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'pf_convergence' in {root}.connectivity.granule_to_golgi
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'after' in {root}.connectivity.golgi_to_granule.postsynaptic
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'after' in {root}.connectivity.parallel_fiber_to_basket.postsynaptic
/mnt/d/GIT/bsb/bsb/config/_make.py:260: ConfigurationWarning: Unknown attribute: 'after' in {root}.connectivity.parallel_fiber_to_stellate.postsynaptic
Clearing data
Traceback (most recent call last):
  File "/home/robin/.pyenv/versions/3.9.1/bin/bsb", line 33, in <module>
    sys.exit(load_entry_point('bsb', 'console_scripts', 'bsb')())
  File "/mnt/d/GIT/bsb/bsb/cli/__init__.py", line 10, in handle_cli
    handle_command(sys.argv[1:], exit=True)
  File "/mnt/d/GIT/bsb/bsb/cli/__init__.py", line 30, in handle_command
    namespace.handler(namespace, dryrun=dryrun)
  File "/mnt/d/GIT/bsb/bsb/cli/commands/__init__.py", line 98, in execute_handler
    self.handler(context)
  File "/mnt/d/GIT/bsb/bsb/cli/commands/_commands.py", line 137, in handler
    network.compile(
  File "/mnt/d/GIT/bsb/bsb/core.py", line 321, in compile
    self.run_placement(p_strats)
  File "/mnt/d/GIT/bsb/bsb/core.py", line 216, in run_placement
    pool.execute(loop)
  File "/mnt/d/GIT/bsb/bsb/services/pool.py", line 292, in execute
    job.execute(self.owner, job.f, job._args, job._kwargs)
  File "/mnt/d/GIT/bsb/bsb/services/pool.py", line 166, in execute
    return f(placement, *args[1:], indicators, **kwargs)
  File "/mnt/d/GIT/bsb/bsb/placement/particle.py", line 62, in place
    system = self._fill_system(chunk, indicators)
  File "/mnt/d/GIT/bsb/bsb/placement/particle.py", line 22, in _fill_system
    particles = [
  File "/mnt/d/GIT/bsb/bsb/placement/particle.py", line 29, in <listcomp>
    "count": indicator.guess(chunk, voxels),
  File "/mnt/d/GIT/bsb/bsb/placement/indicator.py", line 116, in guess
    raise RuntimeError(
RuntimeError: No voxel density data column 'exc' found in any of the following partitions:
* granular_layer: no data
```

is this enough information to resolve the problem?
