### PR TITLE
Add `list_labels`, `get_label_mask` to `Morphology` and fixed #606

### DIFF
--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -442,7 +442,7 @@ class SubTree:
             points = np.ones(len(self), dtype=bool)
         points = np.array(points, copy=False)
         if self._is_shared:
-            self._labels.label(labels, points)
+            self.labels.label(labels, points)
         else:
             if len(points) == len(self) and points.dtype == bool:
                 ctr = 0
@@ -705,12 +705,27 @@ class Morphology(SubTree):
         self.optimize()
         return self._shared._labels.labels
 
+    def list_labels(self):
+        """
+        Return a list of labels present on the morphology.
+        """
+        self.optimize()
+        return sorted(set(_gutil.ichain(self._shared._labels.labels.values())))
+
     def set_label_filter(self, labels):
         """
         Set a label filter, so that `as_filtered` returns copies filtered by these labels.
         """
         self._filter = labels
         return self
+
+    def get_label_mask(self, labels):
+        """
+        Get a mask corresponding to all the points labelled with 1 or more of the given
+        labels
+        """
+        self.optimize()
+        return self.labels.get_mask(labels)
 
     def copy(self):
         """


### PR DESCRIPTION
## Describe the work done

* [X] `get_label_mask` has been added to the `Morphology` class.
* [X] Added `list_labels` to facilitate looking up labels on a morphology.
* [X] Fixed `_labels` and other error of #606

## List which issues this resolves:

fixes #606

## Tasks

* [X] Added tests
* [X] Updated documentation: added docstrings
