### PR TITLE
Fixed `all` method of class _CSIterator

### DIFF
--- a/bsb/storage/interfaces.py
+++ b/bsb/storage/interfaces.py
@@ -930,7 +930,9 @@ class _CSIterator:
         for len_, local_, global_ in zip(lens, locals_, globals_):
             lloc[ptr : ptr + len_] = local_
             gloc[ptr : ptr + len_] = global_
-        return lcol, lloc, gcol, gloc
+            ptr += len_
+        result = lcol, lloc, gcol, gloc
+        yield result
 
 
 class StoredMorphology:

--- a/bsb/storage/interfaces.py
+++ b/bsb/storage/interfaces.py
@@ -931,8 +931,7 @@ class _CSIterator:
             lloc[ptr : ptr + len_] = local_
             gloc[ptr : ptr + len_] = global_
             ptr += len_
-        result = lcol, lloc, gcol, gloc
-        yield result
+        return lcol, lloc, gcol, gloc
 
 
 class StoredMorphology:


### PR DESCRIPTION
Now _CSIterator.all() returns a tuple of 4 numpy arrays of the correct length.