### PR TITLE
Morphology generators

### DIFF
--- a/bsb/__init__.py
+++ b/bsb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.0.0a41"
+__version__ = "4.0.0a42"
 
 import functools
 

--- a/bsb/__init__.py
+++ b/bsb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.0.0a40"
+__version__ = "4.0.0a41"
 
 import functools
 

--- a/bsb/cell_types.py
+++ b/bsb/cell_types.py
@@ -70,8 +70,12 @@ class CellType:
 
     @obj_str_insert
     def __repr__(self):
-        cells_placed = len(self.get_placement_set())
-        placements = len(self.get_placement())
+        if hasattr(self, "scaffold"):
+            cells_placed = len(self.get_placement_set())
+            placements = len(self.get_placement())
+        else:
+            cells_placed = 0
+            placements = "?"
         return f"'{self.name}', {cells_placed} cells, {placements} placement strategies"
 
     def get_placement(self):

--- a/bsb/cell_types.py
+++ b/bsb/cell_types.py
@@ -126,3 +126,16 @@ class CellType:
         for conn_set in self.scaffold.get_connectivity_sets():
             if self is conn_set.presynaptic or self is conn_set.postsynaptic:
                 conn_set.clear()
+
+    # This property was mostly added so that accidental assignment to `ct.morphologies`
+    # instead of `ct.spatial.morphologies` raises an error.
+    @property
+    def morphologies(self):
+        return self.get_morphologies()
+
+    @morphologies.setter
+    def morphologies(self, value):
+        raise AttributeError(
+            "`cell_type.morphologies` is a readonly attribute. Did you mean"
+            " `cell_type.spatial.morphologies`?"
+        )

--- a/bsb/config/__init__.py
+++ b/bsb/config/__init__.py
@@ -26,6 +26,7 @@ from ._attrs import (
     reflist,
     slot,
     property,
+    provide,
     unset,
     pluggable,
     catch_all,
@@ -54,6 +55,7 @@ class ConfigurationModule:
     reflist = staticmethod(reflist)
     slot = staticmethod(slot)
     property = staticmethod(property)
+    provide = staticmethod(provide)
     catch_all = staticmethod(catch_all)
     unset = staticmethod(unset)
 

--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -16,7 +16,12 @@ from ._make import (
     _resolve_references,
 )
 from .types import _wrap_reserved
-from ..exceptions import RequirementError, NoReferenceAttributeSignal, CastError
+from ..exceptions import (
+    RequirementError,
+    NoReferenceAttributeSignal,
+    CastError,
+    CfgReferenceError,
+)
 import builtins
 
 
@@ -791,7 +796,7 @@ class ConfigurationReferenceAttribute(ConfigurationAttribute):
             setattr(instance, self.get_ref_key(), value)
             if self.should_resolve_on_set(instance):
                 if hasattr(instance, "_config_root"):  # pragma: nocover
-                    raise ReferenceError(
+                    raise CfgReferenceError(
                         "Can't autoresolve references without a config root."
                     )
                 _setattr(
@@ -834,7 +839,7 @@ class ConfigurationReferenceAttribute(ConfigurationAttribute):
 
     def resolve_reference(self, instance, remote, key):
         if key not in remote:
-            raise ReferenceError(
+            raise CfgReferenceError(
                 "Reference '{}' of {} does not exist in {}".format(
                     key,
                     self.get_node_name(instance),
@@ -886,7 +891,7 @@ class ConfigurationReferenceListAttribute(ConfigurationReferenceAttribute):
         try:
             remote_keys = builtins.list(iter(value))
         except TypeError:
-            raise ReferenceError(
+            raise CfgReferenceError(
                 "Reference list '{}' of {} is not iterable.".format(
                     value, self.get_node_name(instance)
                 )

--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -15,11 +15,9 @@ from ._make import (
     walk_nodes,
     _resolve_references,
 )
-from .types import TypeHandler, _wrap_reserved
-from ..exceptions import *
-import abc
+from .types import _wrap_reserved
+from ..exceptions import RequirementError, NoReferenceAttributeSignal, CastError
 import builtins
-import itertools
 
 
 def root(root_cls):

--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -419,6 +419,13 @@ class ConfigurationAttribute:
         try:
             value = self.type(value, _parent=instance, _key=self.attr_name)
             self.flag_dirty(instance)
+        except ValueError:
+            # This value error should only arise when users are manually setting
+            # attributes in an already bootstrapped config tree.
+            raise CastError(
+                f"'{value}' is not convertible to {self.type.__name__},"
+                f" for attribute '{self.attr_name}' of {instance}."
+            ) from None
         except (RequirementError, CastError) as e:
             if not hasattr(e, "node") or not e.node:
                 e.node, e.attr = instance, self.attr_name

--- a/bsb/config/_make.py
+++ b/bsb/config/_make.py
@@ -51,7 +51,7 @@ def make_metaclass(cls):
                 # or already precast node. If it is not, we consider it invalid input,
                 # unless the user has specified its own `__init__` function and will deal
                 # with the input arguments there.
-                raise CastError(f"Unexpected positional argument '{primer}'")
+                raise ValueError(f"Unexpected positional argument '{primer}'")
             # Call the base class's new with internal arguments
             instance = meta_subject.__new__(
                 meta_subject, _parent=_parent, _key=_key, **kwargs

--- a/bsb/config/_make.py
+++ b/bsb/config/_make.py
@@ -191,16 +191,10 @@ def compile_postnew(cls, root=False):
                 if value is None and attr.required(kwargs):
                     raise RequirementError(f"Missing required attribute '{name}'")
             except RequirementError as e:
-                if name == getattr(self.__class__, "_config_dynamic_attr", None):
-                    # If the dynamic attribute errors in `__post_new__` the constructor of
-                    # a non dynamic child class was called, and the dynamic attribute is
-                    # no longer required, so silence the error and continue.
-                    pass
-                else:
-                    # Catch both our own and possible `attr.required` RequirementErrors
-                    # and set the node detail before passing it on
-                    e.node = self
-                    raise
+                # Catch both our own and possible `attr.required` RequirementErrors
+                # and set the node detail before passing it on
+                e.node = self
+                raise
         for attr in attrs.values():
             name = attr.attr_name
             if attr.key and attr.attr_name not in kwargs:

--- a/bsb/config/_make.py
+++ b/bsb/config/_make.py
@@ -11,10 +11,7 @@ from ..exceptions import (
 )
 from ..reporting import warn
 from ._hooks import overrides
-from functools import wraps
 from re import sub
-import re
-import itertools
 import warnings
 import errr
 import importlib
@@ -273,9 +270,9 @@ def _bubble_up_warnings(log):
         if hasattr(m, "node"):
             # Unpack the inner Warning that was passed instead of the warning msg
             attr = f".{m.attr.attr_name}" if hasattr(m, "attr") else ""
-            warn(str(m) + " in " + m.node.get_node_name() + attr, type(m))
+            warn(str(m) + " in " + m.node.get_node_name() + attr, type(m), stacklevel=4)
         else:
-            warn(str(m), w.category)
+            warn(str(m), w.category, stacklevel=4)
 
 
 def _get_class_config_attrs(cls):

--- a/bsb/config/_make.py
+++ b/bsb/config/_make.py
@@ -287,7 +287,7 @@ def _get_node_name(self):
         name = "." + str(self._config_key)
     if hasattr(self, "_config_index"):
         if self._config_index is None:
-            name = "{removed}"
+            return "{removed}"
         else:
             name = "[" + str(self._config_index) + "]"
     return self._config_parent.get_node_name() + name

--- a/bsb/config/_make.py
+++ b/bsb/config/_make.py
@@ -335,6 +335,8 @@ def _try_catch(catch, node, key, value):
 
 
 def _get_dynamic_class(node_cls, kwargs):
+    if node_cls is not node_cls._config_dynamic_root:
+        return node_cls
     attr_name = node_cls._config_dynamic_attr
     dynamic_attr = getattr(node_cls, attr_name)
     if attr_name in kwargs:

--- a/bsb/config/_make.py
+++ b/bsb/config/_make.py
@@ -347,9 +347,10 @@ def _get_dynamic_class(node_cls, kwargs):
         loaded_cls_name = dynamic_attr.default
     module_path = ["__main__", node_cls.__module__]
     classmap = getattr(node_cls, "_config_dynamic_classmap", None)
+    interface = getattr(node_cls, "_config_dynamic_root")
     try:
         dynamic_cls = _load_class(
-            loaded_cls_name, module_path, interface=node_cls, classmap=classmap
+            loaded_cls_name, module_path, interface=interface, classmap=classmap
         )
     except DynamicClassInheritanceError:
         mapped_class_msg = _get_mapped_class_msg(loaded_cls_name, classmap)

--- a/bsb/connectivity/strategy.py
+++ b/bsb/connectivity/strategy.py
@@ -51,6 +51,8 @@ class ConnectionStrategy(abc.ABC, SortableByAfter):
 
     @obj_str_insert
     def __repr__(self):
+        if not hasattr(self, "scaffold"):
+            return f"'{self.name}'"
         pre = [ct.name for ct in self.presynaptic.cell_types]
         post = [ct.name for ct in self.postsynaptic.cell_types]
         return f"'{self.name}', connecting {pre} to {post}"

--- a/bsb/exceptions.py
+++ b/bsb/exceptions.py
@@ -27,7 +27,7 @@ _t(
             CastConfigurationError=_e(),
             IndicatorError=_e(),
             RequirementError=_e("node", "attr"),
-            ReferenceError=_e(
+            CfgReferenceError=_e(
                 NoReferenceAttributeSignal=_e(),
             ),
             UnknownConfigAttrError=_e("attributes"),

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -37,7 +37,7 @@ class MorphologySet:
     """
 
     def __init__(self, loaders, m_indices, labels=None):
-        self._m_indices = np.array(m_indices, copy=False)
+        self._m_indices = np.array(m_indices, copy=False, dtype=int)
         self._loaders = loaders
         check_max = np.max(m_indices, initial=-1)
         if check_max >= len(loaders):

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -442,7 +442,7 @@ class SubTree:
             points = np.ones(len(self), dtype=bool)
         points = np.array(points, copy=False)
         if self._is_shared:
-            self._labels.label(labels, points)
+            self.labels.label(labels, points)
         else:
             if len(points) == len(self) and points.dtype == bool:
                 ctr = 0
@@ -705,12 +705,27 @@ class Morphology(SubTree):
         self.optimize()
         return self._shared._labels.labels
 
+    def list_labels(self):
+        """
+        Return a list of labels present on the morphology.
+        """
+        self.optimize()
+        return sorted(set(_gutil.ichain(self._shared._labels.labels.values())))
+
     def set_label_filter(self, labels):
         """
         Set a label filter, so that `as_filtered` returns copies filtered by these labels.
         """
         self._filter = labels
         return self
+
+    def get_label_mask(self, labels):
+        """
+        Get a mask corresponding to all the points labelled with 1 or more of the given
+        labels
+        """
+        self.optimize()
+        return self.labels.get_mask(labels)
 
     def copy(self):
         """

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -58,6 +58,18 @@ class MorphologySet:
     def __contains__(self, value):
         return value in [loader.name for loader in self._loaders]
 
+    def count_morphologies(self):
+        return len(self._loaders)
+
+    def count_unique(self):
+        uniques = []
+        count = 0
+        for m in (m.load() for m in self._loaders):
+            if not any(f == m for f in uniques):
+                uniques.append(m)
+                count += 1
+        return count
+
     def __len__(self):
         return len(self._m_indices)
 

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -66,7 +66,7 @@ class MorphologySet:
 
     @property
     def names(self):
-        return [l.name for l in self._loaders]
+        return [loader.name for loader in self._loaders]
 
     def get_indices(self, copy=True):
         return self._m_indices.copy() if copy else self._m_indices

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -712,6 +712,10 @@ class Morphology(SubTree):
         self._filter = labels
         return self
 
+    @classmethod
+    def empty(cls):
+        return cls([])
+
     def copy(self):
         """
         Copy the morphology.

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -615,10 +615,8 @@ class Morphology(SubTree):
     coordinate or other associated data of a point on the branch.
     """
 
-    def __init__(self, roots, meta=None, shared_buffers=None):
-        super().__init__(roots, sanitize=False)
-        if len(self.roots) < len(roots):
-            warn("None-root branches given as morphology input.", MorphologyWarning)
+    def __init__(self, roots, meta=None, shared_buffers=None, sanitize=False):
+        super().__init__(roots, sanitize=sanitize)
         self._meta = meta if meta is not None else {}
         self._filter = None
         if shared_buffers is None:

--- a/bsb/placement/distributor.py
+++ b/bsb/placement/distributor.py
@@ -1,23 +1,31 @@
 from .. import config
+from ..topology.partition import Partition
 from ..exceptions import EmptySelectionError
 from ..morphologies import MorphologySet
+from .indicator import PlacementIndications
+from dataclasses import dataclass
 import numpy as np
 import abc
+import uuid
+
+
+@dataclass
+class DistributionContext:
+    indicator: PlacementIndications
+    partitions: list[Partition]
 
 
 @config.dynamic(attr_name="strategy", required=True)
 class Distributor(abc.ABC):
     @abc.abstractmethod
-    def distribute(self, partitions, indicator, positions):
+    def distribute(self, positions, context):
         """
         Is called to distribute cell properties.
 
         :param partitions: The partitions the cells were placed in.
-        :type partitions: List[~bsb.topology.partition.Partition]
-        :param indicator: The indicator of the cell type whose properties are being
-          distributed.
-        :param positions: Positions of the cells.
-        :type positions: numpy.ndarray
+        :type context: Additional context information such as the placement indications
+          and partitions.
+        :type context: ~bsb.placement.distributor.DistributionContext
         :returns: An array with the property data
         :rtype: numpy.ndarray
         """
@@ -28,17 +36,22 @@ class Distributor(abc.ABC):
     attr_name="strategy", required=False, default="random", auto_classmap=True
 )
 class MorphologyDistributor(Distributor):
+    may_be_empty = config.attr(type=bool, default=False)
+
     @abc.abstractmethod
-    def distribute(self, partitions, indicator, positions):
+    def distribute(self, positions, morphologies, context):
         """
         Is called to distribute cell morphologies and optionally rotations.
 
-        :param partitions: The partitions the morphologies need to be distributed in.
-        :type partitions: List[~bsb.topology.partition.Partition]
-        :param indicator: The indicator of the cell type whose morphologies are being
-          distributed.
         :param positions: Placed positions under consideration
         :type positions: numpy.ndarray
+        :param morphologies: The template morphology loaders. You can decide to use them
+          and/or generate new ones in the MorphologySet that you produce. If you produce
+          any new morphologies, don't forget to encapsulate them in a
+          :class:`~bsb.storage.interfaces.StoredMorphology` loader, or better yet, use
+          the :class:`~bsb.placement.distributor.MorphologyGenerator`.
+        :param context: The placement indicator and partitions.
+        :type context: ~bsb.placement.distributor.DistributionContext
         :returns: A MorphologySet with assigned morphologies, and optionally a RotationSet
         :rtype: Union[~bsb.morphologies.MorphologySet, Tuple[
           ~bsb.morphologies.MorphologySet, ~bsb.morphologies.RotationSet]]
@@ -46,6 +59,7 @@ class MorphologyDistributor(Distributor):
         pass
 
 
+@config.node
 class RandomMorphologies(MorphologyDistributor, classmap_entry="random"):
     """
     Distributes selected morphologies randomly without rotating them.
@@ -59,23 +73,17 @@ class RandomMorphologies(MorphologyDistributor, classmap_entry="random"):
       }}}
     """
 
-    def distribute(self, partitions, indicator, positions):
+    may_be_empty = config.provide(False)
+
+    def distribute(self, positions, morphologies, context):
         """
         Uses the morphology selection indicators to select morphologies and
         returns a MorphologySet of randomly assigned morphologies
         """
-        sel = indicator.assert_indication("morphologies")
-        loaders = self.scaffold.storage.morphologies.select(*sel)
-        if not loaders:
-            raise EmptySelectionError(
-                f"Given {len(sel)} selectors: did not find any suitable morphologies",
-                sel,
-            )
-        else:
-            ids = np.random.default_rng().integers(len(loaders), size=len(positions))
-        return MorphologySet(loaders, ids)
+        return np.random.default_rng().integers(len(morphologies), size=len(positions))
 
 
+@config.node
 class RoundRobinMorphologies(MorphologyDistributor, classmap_entry="roundrobin"):
     """
     Distributes selected morphologies round robin, values are looped and assigned one by
@@ -90,19 +98,29 @@ class RoundRobinMorphologies(MorphologyDistributor, classmap_entry="roundrobin")
       }}}
     """
 
-    def distribute(self, partitions, indicator, positions):
-        sel = indicator.assert_indication("morphologies")
-        loaders = self.scaffold.storage.morphologies.select(*sel)
-        if not loaders:
-            raise EmptySelectionError(
-                f"Given {len(sel)} selectors: did not find any suitable morphologies",
-                sel,
-            )
-        else:
-            ll = len(loaders)
-            lp = len(positions)
-            ids = np.tile(np.arange(ll), lp // ll + 1)[:lp]
-        return MorphologySet(loaders, ids)
+    may_be_empty = config.provide(False)
+
+    def distribute(self, positions, morphologies, context):
+        ll = len(morphologies)
+        lp = len(positions)
+        return np.tile(np.arange(ll), lp // ll + 1)[:lp]
+
+
+@config.node
+class MorphologyGenerator(MorphologyDistributor, classmap_entry=None):
+    """
+    Special case of the morphology distributor that provides extra convenience when
+    generating new morphologies.
+    """
+
+    may_be_empty = config.attr(type=bool, default=True)
+
+    def distribute(self, positions, morphologies, context):
+        pass
+
+    @abc.abstractmethod
+    def generate(self, positions, morphologies, context):
+        pass
 
 
 @config.dynamic(attr_name="strategy", required=False, default="none", auto_classmap=True)
@@ -112,12 +130,13 @@ class RotationDistributor(Distributor):
     """
 
     @abc.abstractmethod
-    def distribute(self, partitions, indicator, positions):
+    def distribute(self, positions, context):
         pass
 
 
+@config.node
 class ExplicitNoRotations(RotationDistributor, classmap_entry="explicitly_none"):
-    def distribute(self, partitions, indicator, positions):
+    def distribute(self, positions, context):
         return np.zeros((len(positions), 3))
 
 
@@ -127,12 +146,14 @@ class Implicit:
     pass
 
 
+@config.node
 class ImplicitNoRotations(ExplicitNoRotations, Implicit, classmap_entry="none"):
     pass
 
 
+@config.node
 class RandomRotations(RotationDistributor, classmap_entry="random"):
-    def distribute(self, partitions, indicator, positions):
+    def distribute(self, positions, context):
         return np.random.rand(len(positions), 3) * 360
 
 
@@ -144,15 +165,80 @@ class DistributorsNode:
     rotations = config.attr(type=RotationDistributor, default=dict, call_default=True)
     properties = config.catch_all(type=Distributor)
 
-    def _curry(self, partitions, indicator, positions):
+    def __call__(self, key, partitions, indicator, positions, loaders=None):
+        context = DistributionContext(indicator, partitions)
+        if key == "morphologies":
+            distributor = getattr(self, key)
+            if hasattr(distributor, "generate"):
+                distribute = distributor.generate
+            else:
+                distribute = distributor.distribute
+            values = distribute(positions, loaders, context)
+            if isinstance(values, tuple):
+                # Check for accidental tuple return values. If you return a 2 sized
+                # tuple you're still fucked, but the Gods must truly hate you.
+                try:
+                    morphologies, rotations = values
+                except TypeError:
+                    raise ValueError(
+                        "Morphology distributors may only return tuples when they are"
+                        + " to be unpacked as (morphologies, rotations)"
+                    ) from None
+            else:
+                values = (values, None)
+            return values
+        elif key == "rotations":
+            distribute = getattr(self, key).distribute
+        else:
+            distribute = self.properties[key].distribute
+        return distribute(positions, context)
+
+    def _curry(self, partitions, indicator, positions, loaders=None):
         def curried(key):
-            return self(key, partitions, indicator, positions)
+            return self(key, partitions, indicator, positions, loaders)
 
         return curried
 
-    def __call__(self, key, partitions, indicator, positions):
-        if key in ("morphologies", "rotations"):
-            distributor = getattr(self, key)
-        else:
-            distributor = self.properties[key]
-        return distributor.distribute(partitions, indicator, positions)
+    def _specials(self, partitions, indicator, positions):
+        sel = indicator.assert_indication("morphologies")
+        loaders = self.scaffold.storage.morphologies.select(*sel)
+        if not loaders and not self.morphologies.may_be_empty:
+            raise EmptySelectionError(
+                f"Given {len(sel)} selectors: did not find any suitable morphologies",
+                sel,
+            )
+        distr = self._curry(partitions, indicator, positions, loaders)
+        morphologies, rotations = distr("morphologies")
+        if morphologies is not None and (
+            rotations is None or not isinstance(self.rotations, Implicit)
+        ):
+            # If a RotationDistributor is not explicitly marked as `Implicit`, it
+            # overrides the MorphologyDistributor's implicit rotations.
+            rotations = distr("rotations")
+
+        if hasattr(self.morphologies, "generate"):
+            prefix = self._config_parent.name
+            generated = []
+            # Get all the unique morphology objects from the return value and map to them
+            indices = [
+                generated.index(id(m))
+                if id(m) in generated
+                else generated.append(id(m)) or (len(generated) - 1)
+                for m in morphologies
+            ]
+            mr = self.scaffold.morphologies
+            uid = uuid.uuid4()
+            loaders = []
+            for i, gen_morpho in enumerate(generated):
+                name = f"{prefix}-{uid}-{i}"
+                print("generated morpho", gen_morpho)
+                loaders.append(mr.save(name, gen_morpho))
+            morphologies = MorphologySet(loaders, indices)
+        if not isinstance(morphologies, MorphologySet) and morphologies is not None:
+            morphologies = MorphologySet(loaders, morphologies)
+
+        return morphologies, rotations
+
+    def _has_mdistr(self):
+        # This function checks if this distributor node has specified a morpho distributor
+        return self.__class__.morphologies.is_dirty(self)

--- a/bsb/placement/distributor.py
+++ b/bsb/placement/distributor.py
@@ -215,7 +215,6 @@ class DistributorsNode:
             # If a RotationDistributor is not explicitly marked as `Implicit`, it
             # overrides the MorphologyDistributor's implicit rotations.
             rotations = distr("rotations")
-
         if hasattr(self.morphologies, "generate"):
             prefix = self._config_parent.name
             generated = {}
@@ -229,7 +228,8 @@ class DistributorsNode:
             loaders = []
             for gen_morpho, i in generated.items():
                 name = f"{prefix}-{uid}-{i}"
-                loaders.append(mr.save(name, gen_morpho))
+                saved = mr.save(name, gen_morpho)
+                loaders.append(saved)
             morphologies = MorphologySet(loaders, indices)
         if not isinstance(morphologies, MorphologySet) and morphologies is not None:
             morphologies = MorphologySet(loaders, morphologies)

--- a/bsb/placement/distributor.py
+++ b/bsb/placement/distributor.py
@@ -7,12 +7,13 @@ from dataclasses import dataclass
 import numpy as np
 import abc
 import uuid
+from typing import List
 
 
 @dataclass
 class DistributionContext:
     indicator: PlacementIndications
-    partitions: list[Partition]
+    partitions: List[Partition]
 
 
 @config.dynamic(attr_name="strategy", required=True)

--- a/bsb/placement/distributor.py
+++ b/bsb/placement/distributor.py
@@ -218,20 +218,17 @@ class DistributorsNode:
 
         if hasattr(self.morphologies, "generate"):
             prefix = self._config_parent.name
-            generated = []
+            generated = {}
+            indices = []
             # Get all the unique morphology objects from the return value and map to them
-            indices = [
-                generated.index(id(m))
-                if id(m) in generated
-                else generated.append(id(m)) or (len(generated) - 1)
-                for m in morphologies
-            ]
+            for m in morphologies:
+                idx = generated.setdefault(m, len(generated))
+                indices.append(idx)
             mr = self.scaffold.morphologies
             uid = uuid.uuid4()
             loaders = []
-            for i, gen_morpho in enumerate(generated):
+            for gen_morpho, i in generated.items():
                 name = f"{prefix}-{uid}-{i}"
-                print("generated morpho", gen_morpho)
                 loaders.append(mr.save(name, gen_morpho))
             morphologies = MorphologySet(loaders, indices)
         if not isinstance(morphologies, MorphologySet) and morphologies is not None:

--- a/bsb/placement/strategy.py
+++ b/bsb/placement/strategy.py
@@ -35,11 +35,12 @@ class PlacementStrategy(abc.ABC, SortableByAfter):
     @obj_str_insert
     def __repr__(self):
         config_name = self.name
-        strategy_name = self.strategy
+        if not hasattr(self, "scaffold"):
+            return f"'{config_name}'"
         part_str = ""
         if len(self.partitions):
             partition_names = [p.name for p in self.partitions]
-            part_str = f" into {partitions}"
+            part_str = f" into {partition_names}"
         ct_names = [ct.name for ct in self.cell_types]
         return f"'{config_name}', placing {ct_names}{part_str}"
 

--- a/bsb/storage/interfaces.py
+++ b/bsb/storage/interfaces.py
@@ -691,7 +691,7 @@ class MorphologyRepository(Interface, engine_key="morphologies"):
         """
         List all the names of the morphologies in the repository.
         """
-        return [l.name for l in self.all()]
+        return [loader.name for loader in self.all()]
 
 
 class ConnectivitySet(Interface):
@@ -921,7 +921,7 @@ class _CSIterator:
             gchunks.append(gchunk)
             locals_.append(data[0])
             globals_.append(data[1])
-        lens = [len(l) for l in locals_]
+        lens = [len(lcl) for lcl in locals_]
         lcol = np.repeat([c.id for c in lchunks], lens)
         gcol = np.repeat([c.id for c in gchunks], lens)
         lloc = np.empty((sum(lens), 3), dtype=int)
@@ -959,3 +959,10 @@ class StoredMorphology:
     @functools.cache
     def _cached_load(self, labels):
         return self.load().set_label_filter(labels).as_filtered()
+
+
+class GeneratedMorphology(StoredMorphology):
+    def __init__(self, name, generated, meta):
+        self.name = name
+        self._loader = lambda: generated
+        self._meta = meta

--- a/bsb/storage/interfaces.py
+++ b/bsb/storage/interfaces.py
@@ -350,6 +350,12 @@ class PlacementSet(Interface):
         """
         pass
 
+    def count_morphologies(self):
+        """
+        Must return the number of different morphologies used in the set.
+        """
+        return self.load_morphologies(allow_empty=True).count_morphologies()
+
     @abc.abstractmethod
     def __iter__(self):
         pass
@@ -485,6 +491,7 @@ class PlacementSet(Interface):
         :returns: An iterator with 6 coordinates per cell: 3 min and 3 max coords, the
           bounding box of that cell's translated and rotated morphology.
         :rtype: Iterator[Tuple[float, float, float, float, float, float]]
+        :raises: DatasetNotFoundError if no morphologies are found.
         """
         if morpho_cache is None:
             mset = self.load_morphologies()
@@ -518,7 +525,7 @@ class PlacementSet(Interface):
         return BoxTree(list(self.load_boxes(morpho_cache=morpho_cache)))
 
     def _requires_morpho_mapping(self):
-        return self._morphology_labels is not None
+        return self._morphology_labels is not None and self.count_morphologies()
 
     def _morpho_backmap(self, locs):
         locs = locs.copy()

--- a/bsb/storage/interfaces.py
+++ b/bsb/storage/interfaces.py
@@ -223,7 +223,10 @@ class PlacementSet(Interface):
     @obj_str_insert
     def __repr__(self):
         cell_type = self.cell_type
-        ms = self.load_morphologies()
+        try:
+            ms = self.load_morphologies()
+        except Exception:
+            return f"cell type: '{cell_type.name}'"
         if not len(ms):
             mstr = "without morphologies"
         else:

--- a/bsb/unittest/engines.py
+++ b/bsb/unittest/engines.py
@@ -217,10 +217,8 @@ class TestPlacementSet(
     def test_load_no_morphologies(self):
         self.network.compile()
         ps = self.network.get_placement_set("test_cell")
-        ms = ps.load_morphologies()
-        # Define final behaviour in #552, for now, just confirm that no data sneaks in.
-        self.assertIsInstance(ms, MorphologySet, "missing data should still be MS")
-        self.assertEqual(0, len(ms), "there should not be morphology data")
+        with self.assertRaises(DatasetNotFoundError, msg="missing morphos should raise"):
+            ps.load_morphologies()
 
     def test_load_morphologies(self):
         self.network.cell_types.test_cell.spatial.morphologies.append(
@@ -232,7 +230,8 @@ class TestPlacementSet(
         self.network.morphologies.save("test_cell_B", mB, overwrite=True)
         for i in range(10):
             ps = self.network.get_placement_set("test_cell")
-            ms = ps.load_morphologies()
+            with self.assertRaises(DatasetNotFoundError, msg="no morphos yet -> raise"):
+                ps.load_morphologies()
             self.network.compile(clear=True)
             ps = self.network.get_placement_set("test_cell")
             ms = ps.load_morphologies()

--- a/bsb/unittest/parallel.py
+++ b/bsb/unittest/parallel.py
@@ -94,7 +94,8 @@ def timeout(timeout, abort=False):
                     file=sys.stderr,
                     flush=True,
                 )
-                MPI.abort(1)
+                if MPI.get_size() > 1:
+                    MPI.abort(1)
 
         return timed_f
 

--- a/docs/morphologies/intro.rst
+++ b/docs/morphologies/intro.rst
@@ -433,6 +433,15 @@ a :class:`~.morphologies.RotationSet`.
 	block.
 
 
+Morphology generators
+~~~~~~~~~~~~~~~~~~~~~
+
+Continuing on the morphology distributor, one can also make a specialized generator. The
+generator takes the same arguments as a distributor, but returns a list of Morphology
+objects, and the morphology indices to make use of them. It can also return rotations
+as a 3rd return value.
+
+
 MorphologySets
 --------------
 

--- a/examples/distributors/morphology_generator.py
+++ b/examples/distributors/morphology_generator.py
@@ -1,0 +1,10 @@
+from bsb.placement.distributor import MorphologyGenerator
+from bsb.morphologies import Morphology, Branch
+import numpy as np
+
+
+class TouchTheBottomMorphologies(MorphologyGenerator, classmap_entry="touchdown"):
+    def generate(self, positions, morphologies, context):
+        return [
+            Morphology([Branch([pos, [pos[1], 0, pos[2]]], [1, 1])]) for pos in positions
+        ], np.arange(len(positions))

--- a/examples/distributors/space_aware_morphology_distributor.py
+++ b/examples/distributors/space_aware_morphology_distributor.py
@@ -1,0 +1,29 @@
+from bsb.placement.distributor import MorphologyDistributor
+import numpy as np
+from scipy.stats.distributions import norm
+
+
+class SmallerTopMorphologies(MorphologyDistributor, classmap_entry="small_top"):
+    def distribute(self, positions, morphologies, context):
+        # Get the maximum Y coordinate of all the partitions boundaries
+        top_of_layers = np.maximum([p.data.mdc[1] for p in context.partitions])
+        depths = top_of_layers - positions[:, 1]
+        # Get all the heights of the morphologies, by peeking into the morphology metadata
+        msizes = [
+            loader.get_meta()["mdc"][1] - loader.get_meta()["ldc"][1]
+            for loader in morphologies
+        ]
+        # Pick deeper positions for bigger morphologies.
+        weights = np.column_stack(
+            [norm(loc=size, scale=20).pdf(depths) for size in msizes]
+        )
+        # The columns are the morphology ids, so make an arr from 0 to n morphologies.
+        picker = np.arange(weights.shape[1])
+        # An array to store the picked weights
+        picked = np.empty(weights.shape[0], dtype=int)
+        rng = np.default_rng()
+        for i, p in enumerate(weights):
+            # Pick a value from 0 to n, based on the weights.
+            picked[i] = rng.choice(picker, p=p)
+        # Return the picked morphologies for each position.
+        return picked

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,6 @@ pynrrd==0.4.2
 toml==0.10.2
 morphio==3.3.2
 appdirs==1.4.4
+
 # Plugins
-bsb-hdf5==0.4.1
+bsb-hdf5==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ toml==0.10.2
 morphio==3.3.2
 appdirs==1.4.4
 # Plugins
-bsb-hdf5==0.4.0
+bsb-hdf5==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 requires = [
-    "bsb-hdf5~=0.4",
+    "bsb-hdf5~=0.4.1",
     "h5py~=3.0",
     "numpy~=1.19",
     "scipy~=1.5",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 requires = [
-    "bsb-hdf5~=0.4.1",
+    "bsb-hdf5~=0.4.2",
     "h5py~=3.0",
     "numpy~=1.19",
     "scipy~=1.5",

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,12 +1,22 @@
-import unittest, os, sys, numpy as np, h5py, json
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+import unittest
+import sys
+import numpy as np
+import json
 from bsb.core import Scaffold
 from bsb import config
 from bsb.config import from_json, Configuration, _attrs
 from bsb.config import types
-from bsb.exceptions import *
+from bsb.exceptions import (
+    CfgReferenceError,
+    RequirementError,
+    ConfigurationWarning,
+    CastError,
+    UnfitClassCastError,
+    DynamicClassInheritanceError,
+    UnresolvedClassCastError,
+    DynamicClassNotFoundError,
+    ClassMapMissingError,
+)
 from bsb.topology.region import RegionGroup
 from bsb.unittest import get_config_path
 

--- a/tests/test_distributors.py
+++ b/tests/test_distributors.py
@@ -1,21 +1,35 @@
-import unittest, os, sys, numpy as np, h5py, json, string, random
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
-from bsb.exceptions import *
+import unittest
+from bsb.exceptions import DistributorError, DatasetNotFoundError, EmptySelectionError
 from bsb.core import Scaffold
-from bsb.cell_types import CellType
-from bsb.config import from_json, Configuration
-from bsb.morphologies.selector import NameSelector
-from bsb.placement.distributor import MorphologyDistributor
+from bsb.config import Configuration
 from bsb.unittest import skip_parallel
+from bsb.placement.distributor import MorphologyDistributor, MorphologyGenerator
+from bsb.morphologies import Morphology
+
+
+class OneNoneDistributor(MorphologyDistributor):
+    def distribute(self, *args):
+        return None
+
+
+class TupleNoneDistributor(MorphologyDistributor):
+    def distribute(self, *args):
+        return None, None
+
+
+class SameEmptyGenerator(MorphologyGenerator):
+    def generate(self, pos, loaders, context):
+        return [Morphology.empty()] * len(pos)
+
+
+class ManyEmptyGenerator(MorphologyGenerator):
+    def generate(self, pos, loaders, context):
+        return [Morphology.empty() for _ in range(len(pos))]
 
 
 class TestMorphologyDistributor(unittest.TestCase):
-    @skip_parallel
-    # Errors during parallel jobs cause MPI_Abort, untestable scenario.
-    def test_empty_selection(self):
-        cfg = Configuration.default(
+    def setUp(self):
+        self.cfg = Configuration.default(
             regions=dict(reg=dict(children=["a"])),
             partitions=dict(a=dict(thickness=100)),
             cell_types=dict(
@@ -29,6 +43,31 @@ class TestMorphologyDistributor(unittest.TestCase):
                 )
             ),
         )
-        netw = Scaffold(cfg)
+        self.netw = Scaffold(self.cfg)
+
+    @skip_parallel
+    # Errors during parallel jobs cause MPI_Abort, untestable scenario.
+    def test_empty_selection(self):
         with self.assertRaisesRegex(DistributorError, "NameSelector"):
-            netw.compile(append=True)
+            self.netw.compile(append=True)
+
+    @skip_parallel
+    # Errors during parallel jobs cause MPI_Abort, untestable scenario.
+    def test_none_returns(self):
+        self.netw.morphologies.save("bs", Morphology.empty(), overwrite=True)
+        self.netw.cell_types.a.spatial.morphologies = [{"names": ["*"]}]
+        self.netw.placement.a.distribute.morphologies = OneNoneDistributor()
+        self.netw.compile(append=True)
+        ps = self.netw.get_placement_set("a")
+        self.assertTrue(len(ps) > 0, "should've still placed cells")
+        with self.assertRaises(DatasetNotFoundError, msg="shouldnt have morphos"):
+            ps.load_morphologies()
+        self.netw.placement.a.distribute.morphologies = TupleNoneDistributor()
+        self.netw.compile(append=True)
+        self.assertTrue(len(ps) > 0, "should've still placed cells")
+        with self.assertRaises(DatasetNotFoundError, msg="shouldnt have morphos"):
+            ps.load_morphologies()
+
+    def test_generators(self):
+        self.netw.placement.a.distribute.morphologies = SameEmptyGenerator()
+        self.netw.compile()

--- a/tests/test_distributors.py
+++ b/tests/test_distributors.py
@@ -33,7 +33,7 @@ class TestMorphologyDistributor(unittest.TestCase):
             regions=dict(reg=dict(children=["a"])),
             partitions=dict(a=dict(thickness=100)),
             cell_types=dict(
-                a=dict(spatial=dict(radius=2, density=1e-3, morphologies=[{"names": []}]))
+                a=dict(spatial=dict(radius=2, density=1e-4, morphologies=[{"names": []}]))
             ),
             placement=dict(
                 a=dict(
@@ -68,6 +68,26 @@ class TestMorphologyDistributor(unittest.TestCase):
         with self.assertRaises(DatasetNotFoundError, msg="shouldnt have morphos"):
             ps.load_morphologies()
 
-    def test_generators(self):
+    def test_same_generators(self):
         self.netw.placement.a.distribute.morphologies = SameEmptyGenerator()
         self.netw.compile()
+        ps = self.netw.get_placement_set("a")
+        ms = ps.load_morphologies()
+        morphologies = list(ms.iter_morphologies(unique=True))
+        self.assertEqual(len(ps), len(ms), "equal data")
+        self.assertEqual(
+            len(ps.get_loaded_chunks()),
+            len(morphologies),
+            "expected each chunk to generate 1 unique empty morphology",
+        )
+
+    def test_many_generators(self):
+        self.netw.placement.a.distribute.morphologies = ManyEmptyGenerator()
+        self.netw.compile()
+        ps = self.netw.get_placement_set("a")
+        ms = ps.load_morphologies()
+        morphologies = list(ms.iter_morphologies(unique=True))
+        self.assertEqual(len(ps), len(ms), "equal data")
+        self.assertEqual(
+            len(ps), len(morphologies), "expected 1 unique morphology per cell"
+        )

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,14 +1,8 @@
-import unittest, os, sys, numpy as np, h5py, json
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
-from bsb.core import Scaffold
+import unittest
+import os
 from bsb import config
-from bsb.config import from_json, Configuration
 from bsb.config.refs import Reference
-from bsb.config import types
-from bsb.exceptions import *
-from bsb.topology import Region, Partition
+from bsb.exceptions import CfgReferenceError
 
 
 def relative_to_tests_folder(path):
@@ -44,7 +38,7 @@ class Root430:
 
 class TestIssues(unittest.TestCase):
     def test_430(self):
-        with self.assertRaises(ReferenceError, msg="Regression of issue #430"):
+        with self.assertRaises(CfgReferenceError, msg="Regression of issue #430"):
             config = Root430(
                 examples=dict(), extensions=dict(x=dict(ex_mut=4, ref="missing"))
             )

--- a/tests/test_morphologies.py
+++ b/tests/test_morphologies.py
@@ -309,6 +309,27 @@ class TestMorphologySet(NumpyTestCase, unittest.TestCase):
         self.assertEqual([], self.sets[0].names, "expected empty names list")
         self.assertEqual(["ello"], self.sets[1].names, "expected matching names list")
 
+    def test_count(self):
+        self.assertEqual(0, self.sets[0].count_morphologies(), "expected no morphologies")
+        self.assertEqual(1, self.sets[1].count_morphologies(), "expected fake loader")
+
+    def test_count_unique(self):
+        self.assertEqual(0, self.sets[0].count_unique(), "expected no unique")
+        self.assertEqual(1, self.sets[1].count_unique(), "expected fake loader")
+        ms = MorphologySet([self._fake_loader("ello")] * 3, [0, 0, 0])
+        self.assertEqual(1, ms.count_unique(), "expected fake loader")
+        ms = MorphologySet(
+            [
+                self._fake_loader("ello"),
+                self._fake_loader("ello"),
+                StoredMorphology(
+                    "oh", lambda: Morphology([Branch([[0, 0, 0]], [0])]), dict()
+                ),
+            ],
+            [0, 0, 0],
+        )
+        self.assertEqual(2, ms.count_unique(), "expected 2 uniques")
+
     def test_oob(self):
         with self.assertRaises(IndexError):
             MorphologySet([self._fake_loader("ello")], [0, 1, 0])


### PR DESCRIPTION
## Describe the work done

I need to expand the docs a bit, but now you can inherit from `MorphologyGenerator`, and just return the new `Morphology` objects, and they will all be automatically saved and turned into a `MorphologySet`. The interface also changed and a lot more types of return values are accepted, if @francesshei and @drodarie  could let me know any distributor and generator feedback, would be much appreciated

## List which issues this resolves:

closes #597, closes #552.

## Tasks

* [X] Added tests
* [x] Updated documentation:
  * [x] Give distributor and generator examples.
