### PR TITLE
Fixed inconsistent `_pick_locations` return values for 0 locations 

### DIFF
--- a/bsb/connectivity/detailed/shared.py
+++ b/bsb/connectivity/detailed/shared.py
@@ -1,9 +1,9 @@
 from itertools import chain
-from functools import reduce, cache
+from functools import cache
 import numpy as np
 from ...storage import Chunk
 from ...reporting import warn
-from ...exceptions import *
+from ...exceptions import ConnectivityWarning
 
 
 class Intersectional:

--- a/bsb/connectivity/detailed/voxel_intersection.py
+++ b/bsb/connectivity/detailed/voxel_intersection.py
@@ -100,7 +100,7 @@ class VoxelIntersection(Intersectional, ConnectionStrategy):
                     locations = self._pick_locations(
                         target, cand, tvoxels, cvoxels, overlap
                     )
-                    if locations != ([],[]):
+                    if locations != ([], []):
                         data_acc.append(locations)
 
         # Preallocating and filling is faster than `np.concatenate` :shrugs:

--- a/bsb/connectivity/detailed/voxel_intersection.py
+++ b/bsb/connectivity/detailed/voxel_intersection.py
@@ -100,7 +100,8 @@ class VoxelIntersection(Intersectional, ConnectionStrategy):
                     locations = self._pick_locations(
                         target, cand, tvoxels, cvoxels, overlap
                     )
-                    data_acc.append(locations)
+                    if locations != ([],[]):
+                        data_acc.append(locations)
 
         # Preallocating and filling is faster than `np.concatenate` :shrugs:
         acc_idx = np.cumsum(

--- a/bsb/connectivity/detailed/voxel_intersection.py
+++ b/bsb/connectivity/detailed/voxel_intersection.py
@@ -100,8 +100,7 @@ class VoxelIntersection(Intersectional, ConnectionStrategy):
                     locations = self._pick_locations(
                         target, cand, tvoxels, cvoxels, overlap
                     )
-                    if locations != ([], []):
-                        data_acc.append(locations)
+                    data_acc.append(locations)
 
         # Preallocating and filling is faster than `np.concatenate` :shrugs:
         acc_idx = np.cumsum(
@@ -125,6 +124,8 @@ class VoxelIntersection(Intersectional, ConnectionStrategy):
 
     def _pick_locations(self, tid, cid, tvoxels, cvoxels, overlap):
         n = int(self.contacts.draw(1))
+        if n <= 0:
+            return np.empty((0, 3), dtype=int), np.empty((0, 3), dtype=int)
         tlocs = []
         clocs = []
         for i in _rng.integers(len(overlap), size=n):

--- a/bsb/connectivity/detailed/voxel_intersection.py
+++ b/bsb/connectivity/detailed/voxel_intersection.py
@@ -137,10 +137,9 @@ class VoxelIntersection(Intersectional, ConnectionStrategy):
         weights = [len(c) * len(t) for c, t in pool]
         tlocs = []
         clocs = []
-        for tpick, cpick in random.choices(pool, weights, k=n):
-            tlocs.append((tid, *random.choice(tpick)))
+        for cpick, tpick in random.choices(pool, weights, k=n):
             clocs.append((cid, *random.choice(cpick)))
-        print(tlocs, clocs)
+            tlocs.append((tid, *random.choice(tpick)))
         return tlocs, clocs
 
 

--- a/bsb/connectivity/detailed/voxel_intersection.py
+++ b/bsb/connectivity/detailed/voxel_intersection.py
@@ -126,14 +126,21 @@ class VoxelIntersection(Intersectional, ConnectionStrategy):
         n = int(self.contacts.draw(1))
         if n <= 0:
             return np.empty((0, 3), dtype=int), np.empty((0, 3), dtype=int)
+        cpool = cvoxels.get_data([c for c, _ in overlap])
+        tpool = [tvoxels.get_data(t) for _, t in overlap]
+        pool = np.column_stack(
+            (
+                np.repeat(cpool, [len(t) for t in tpool]),
+                np.array([*ichain(tpool)], dtype=object),
+            )
+        )
+        weights = [len(c) * len(t) for c, t in pool]
         tlocs = []
         clocs = []
-        for i in _rng.integers(len(overlap), size=n):
-            cv, tvs = overlap[i]
-            cpool = cvoxels.get_data(cv)[0]
-            tpool = [*ichain(tvoxels.get_data(tvs).reshape(-1))]
-            tlocs.extend((tid, *t) for t in random.choices(tpool, k=n))
-            clocs.extend((cid, *c) for c in random.choices(cpool, k=n))
+        for tpick, cpick in random.choices(pool, weights, k=n):
+            tlocs.append((tid, *random.choice(tpick)))
+            clocs.append((cid, *random.choice(cpick)))
+        print(tlocs, clocs)
         return tlocs, clocs
 
 

--- a/bsb/connectivity/strategy.py
+++ b/bsb/connectivity/strategy.py
@@ -1,7 +1,7 @@
 from .. import config
 from ..config import refs, types
 from .._util import SortableByAfter, obj_str_insert
-from ..reporting import report
+from ..reporting import report, warn
 import abc
 from itertools import chain
 
@@ -110,10 +110,15 @@ class ConnectionStrategy(abc.ABC, SortableByAfter):
             for chunk in from_chunks
             if (roi := self.get_region_of_interest(chunk))
         }
+        if not rois:
+            warn(
+                f"No overlap found between {[pre.name for pre in pre_types]} and "
+                f"{[post.name for post in self.postsynaptic.cell_types]} "
+                f"in '{self.name}'."
+            )
         for chunk, roi in rois.items():
             job = pool.queue_connectivity(self, chunk, roi, deps=deps)
             self._queued_jobs.append(job)
-
         report(f"Queued {len(self._queued_jobs)} jobs for {self.name}", level=2)
 
     def get_cell_types(self):

--- a/bsb/core.py
+++ b/bsb/core.py
@@ -302,14 +302,14 @@ class Scaffold:
                     + " what to do with existing data."
                 )
             if clear:
-                print("Clearing data")
+                report("Clearing data", level=2)
                 self.clear_placement()
                 self.clear_connectivity()
             elif redo:
                 # In order to properly redo things, we clear some placement and connection
                 # data, but since multiple placement/connection strategies can contribute
                 # to the same sets we might be wiping their data too, and they will need
-                # to be cleared and reran as well, might cause a large chain reaction.
+                # to be cleared and reran as well.
                 p_strats, c_strats = self._redo_chain(p_strats, c_strats, skip, force)
             # else:
             #   append mode is luckily simpler, just don't clear anything :)


### PR DESCRIPTION
Sometimes running the voxel_intersection strategy (e.g. connecting Golgi cells by means of gap junctions) yields the following error
```  
File "/home/alessio/Documenti/GitHub/bsb/bsb/connectivity/detailed/voxel_intersection.py", line 116, in _match_voxel_intersection
    tlocs[s:e] = tblock
ValueError: could not broadcast input array from shape (0,) into shape (0,3)
````
I found that this error happens when tblock is an empty list, which is due to the fact that sometimes the _pick_locations method called at line 100 of voxel_intersection.py returns ([ ],[ ]). Checking if the output of _pick_locations called at line 100 is not ([ ],[ ]) in order to decide whether to append it to data_acc or not (original line 103) solves the problem.