### PR TITLE
Debug/branch.versor with single-point branches

### DIFF
--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -1423,7 +1423,9 @@ class Branch:
         :param return_max = False: if True the function only returns the max value of displacements, otherwise the entire array.
         """
         try:
-            versor = (self.points[idx_end] - self.points[idx_start]) / np.linalg.norm(self.points[idx_end] - self.points[idx_start])
+            start = self.points[idx_start]
+            end = self.points[idx_end]
+            versor = (end - start) / np.linalg.norm(end - start)
             displacements = np.linalg.norm(
                 np.cross(versor, (self.points[idx_start:idx_end+1] - self.points[idx_start])), axis=1
             )

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -571,7 +571,7 @@ class SubTree:
         for root in self.roots:
             root.translate(on - root.points[0])
         return self
-        
+
     def simplify_branches(self, epsilon):
         """
         Apply Ramer–Douglas–Peucker algorithm to all points of all branches of the SubTree.
@@ -579,7 +579,6 @@ class SubTree:
         """
         for branch in self.branches:
             branch.simplify(epsilon)
-
 
     def voxelize(self, N):
         """
@@ -854,7 +853,7 @@ class Morphology(SubTree):
                 branch_copy_map[branch] = nbranch
         # Construct and return the morphology
         return self.__class__(roots, meta=self.meta.copy())
-    
+
     def simplify(self, *args, optimize=True, **kwargs):
         super().simplify_branches(*args, **kwargs)
         if optimize:
@@ -1415,7 +1414,7 @@ class Branch:
                 return i
         return len(self) - 1
 
-    def get_axial_distance(self, idx_start = 0, idx_end = -1, return_max = False):
+    def get_axial_distance(self, idx_start=0, idx_end=-1, return_max=False):
         """
         Return the displacements or its max value of a subset of branch points from its axis vector.
         :param idx_start = 0: index of the first point of the subset.
@@ -1423,9 +1422,15 @@ class Branch:
         :param return_max = False: if True the function only returns the max value of displacements, otherwise the entire array.
         """
         try:
-            versor = (self.points[idx_end] - self.points[idx_start]) / np.linalg.norm(self.points[idx_end] - self.points[idx_start])
+            start = self.points[idx_start]
+            end = self.points[idx_end]
+            versor = (end - start) / np.linalg.norm(end - start)
             displacements = np.linalg.norm(
-                np.cross(versor, (self.points[idx_start:idx_end+1] - self.points[idx_start])), axis=1
+                np.cross(
+                    versor,
+                    (self.points[idx_start : idx_end + 1] - self.points[idx_start]),
+                ),
+                axis=1,
             )
             if return_max:
                 return np.max(displacements)
@@ -1434,8 +1439,7 @@ class Branch:
         except IndexError:
             raise EmptyBranchError("Selected an empty subset of points") from None
 
-
-    def simplify(self, epsilon, idx_start = 0, idx_end = -1):
+    def simplify(self, epsilon, idx_start=0, idx_end=-1):
         """
         Apply Ramer–Douglas–Peucker algorithm to all points or a subset of points of the branch.
         :param epsilon: Epsilon to be used in the algorithm.
@@ -1451,7 +1455,7 @@ class Branch:
 
         reduced = []
         skipped = deque()
-        
+
         while True:
             dists = self.get_axial_distance(idx_start, idx_end)
             try:

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -572,10 +572,10 @@ class SubTree:
             root.translate(on - root.points[0])
         return self
         
-    def simplify(self, epsilon):
+    def simplify_branches(self, epsilon):
         for branch in self.branches:
-            reduced = np.unique(branch.simplify(epsilon))
-            if len(reduced) > 0:
+            if len(branch.points):
+                reduced = np.unique(branch.simplify(epsilon))
                 branch.points = branch.points[reduced]
                 branch.radii = branch.radii[reduced]
 
@@ -855,7 +855,7 @@ class Morphology(SubTree):
         return self.__class__(roots, meta=self.meta.copy())
     
     def simplify(self, *args, optimize=True, **kwargs):
-        super().simplify(*args, **kwargs)
+        super().simplify_branches(*args, **kwargs)
         if optimize:
             self.optimize()
 
@@ -1441,11 +1441,11 @@ class Branch:
             result1 = self.simplify(epsilon, idx_start, index - 1)
             result2 = self.simplify(epsilon, index, idx_end)
 
-            reduced = np.vstack((result1, result2))
+            reduced = np.concatenate((result1, result2))
         else:
             reduced = np.array([idx_start, idx_end])
 
-        return reduced.reshape(-1)
+        return reduced
 
     @functools.wraps(SubTree.cached_voxelize)
     @functools.cache

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -573,6 +573,10 @@ class SubTree:
         return self
         
     def simplify_branches(self, epsilon):
+        """
+        Apply Ramer–Douglas–Peucker algorithm to all points of all branches of the SubTree.
+        :param epsilon: Epsilon to be used in the algorithm.
+        """
         for branch in self.branches:
             branch.simplify(epsilon)
 
@@ -1421,6 +1425,12 @@ class Branch:
 
 
     def simplify(self, epsilon, idx_start = 0, idx_end = -1):
+        """
+        Apply Ramer–Douglas–Peucker algorithm to all points or a subset of points of the branch.
+        :param epsilon: Epsilon to be used in the algorithm.
+        :param idx_start = 0: Index of the first element of the subset of points to be reduced.
+        :param epsilon = -1: Index of the last element of the subset of points to be reduced.
+        """
         if len(self.points) < 3:
             return
         if idx_end == -1:

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -576,11 +576,8 @@ class SubTree:
         for branch in self.branches:
             reduced = np.unique(branch.simplify(epsilon))
             if len(reduced) > 0:
-                print(branch.points.shape)
-                print(branch.points[reduced].shape)
                 branch.points = branch.points[reduced]
                 branch.radii = branch.radii[reduced]
-                print("H",self.points)
 
 
     def voxelize(self, N):

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -1132,7 +1132,11 @@ class Branch:
         Return the normalized vector of the axis connecting the start and terminal points.
         """
         try:
-            return (self.end - self.start) / np.linalg.norm(self.end - self.start)
+            versor = (self.end - self.start) / np.linalg.norm(self.end - self.start)
+            if np.isnan(versor).any():
+                raise EmptyBranchError("Empty branch has no versor")
+            else:
+                return versor
         except IndexError:
             raise EmptyBranchError("Empty branch has no versor") from None
 
@@ -1158,7 +1162,7 @@ class Branch:
     def max_displacement(self):
         """
         Return the max displacement of the branch points from its axis vector.
-        """
+        """        
         try:
             displacements = np.linalg.norm(
                 np.cross(self.versor, (self.points - self.start)), axis=1

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -1421,7 +1421,7 @@ class Branch:
 
         vec = end - start
         cross = np.cross(vec, start - self.points)
-        return np.divide(np.linalg.norm(cross, axis = 0), np.linalg.norm(vec))
+        return np.divide(np.linalg.norm(cross, axis = 1), np.linalg.norm(vec))
 
 
     def simplify(self, epsilon, idx_start = 0, idx_end = -1):
@@ -1449,12 +1449,12 @@ class Branch:
             index = np.argmax(dists)
             dmax = dists[index]
             
-            reduced.append(idx_start)
-            reduced.append(idx_end)
+            should_loop = False
             if dmax > epsilon and idx_end - idx_start > 1:
                 skipped.append([index, idx_end])
                 idx_end = index - 1
-                should_loop = False
+                reduced.append(idx_start)
+                reduced.append(idx_end)
             elif len(skipped) > 0:
                 idx_pair = skipped.popleft()
                 idx_start = idx_pair[0]
@@ -1463,7 +1463,6 @@ class Branch:
             else:
                 reduced.append(idx_start)
                 reduced.append(idx_end)
-                should_loop = False
 
 
         reduced = np.unique(reduced)

--- a/tests/test_morphologies.py
+++ b/tests/test_morphologies.py
@@ -230,7 +230,7 @@ class TestMorphologies(NumpyTestCase, unittest.TestCase):
             np.array([[0, 0, 0], [1, 1, 0], [0, 4, 0], [0, 6, 0], [2, 4, 8]]),
             "It has failed rdp with epsilon 0",
         )
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(ValueError, "It should throw a ValueError") as context:
             m_epsilon_0.simplify(epsilon=-1)
 
 

--- a/tests/test_morphologies.py
+++ b/tests/test_morphologies.py
@@ -202,7 +202,7 @@ class TestMorphologies(NumpyTestCase, unittest.TestCase):
         
         m = Morphology([branch_one()])
         m.simplify(epsilon=10)
-        #self.assertClose(m.branches[0].points, np.array([[0, 0, 0], [0, 4, 0]]), "It has failed base rdp")
+        self.assertClose(m.branches[0].points, np.array([[0, 0, 0], [0, 4, 0]]), "It has failed base rdp")
         
         m_empty = Morphology([branch_two()])
         m_empty.simplify(epsilon=1)
@@ -220,7 +220,7 @@ class TestMorphologies(NumpyTestCase, unittest.TestCase):
         m_epsilon_0.simplify(epsilon=0)
         self.assertClose(m_epsilon_0.branches[0].points, np.array([[0, 0, 0], [1, 1, 0], [0, 4, 0]]), "It has failed rdp with epsilon 0")
         with self.assertRaises(ValueError) as context:
-            m.simplify(epsilon=-1)
+            m_epsilon_0.simplify(epsilon=-1)
 
 
 class TestMorphologyLabels(NumpyTestCase, unittest.TestCase):

--- a/tests/test_morphologies.py
+++ b/tests/test_morphologies.py
@@ -230,7 +230,7 @@ class TestMorphologies(NumpyTestCase, unittest.TestCase):
             np.array([[0, 0, 0], [1, 1, 0], [0, 4, 0], [0, 6, 0], [2, 4, 8]]),
             "It has failed rdp with epsilon 0",
         )
-        with self.assertRaises(ValueError, "It should throw a ValueError") as context:
+        with self.assertRaises(ValueError, msg="It should throw a ValueError") as context:
             m_epsilon_0.simplify(epsilon=-1)
 
 

--- a/tests/test_morphologies.py
+++ b/tests/test_morphologies.py
@@ -186,10 +186,12 @@ class TestMorphologies(NumpyTestCase, unittest.TestCase):
                     [
                         [0, 0, 0],
                         [1, 1, 0],
-                        [0, 4, 0]
+                        [0, 4, 0],
+                        [0, 6, 0],
+                        [2, 4, 8]
                     ]
                 ),
-                np.array([0, 1, 2]),
+                np.array([0, 1, 2, 2, 1]),
             )
         
         def branch_two():
@@ -202,7 +204,7 @@ class TestMorphologies(NumpyTestCase, unittest.TestCase):
         
         m = Morphology([branch_one()])
         m.simplify(epsilon=10)
-        self.assertClose(m.branches[0].points, np.array([[0, 0, 0], [0, 4, 0]]), "It has failed base rdp")
+        self.assertClose(m.branches[0].points, np.array([[0, 0, 0], [2, 4, 8]]), "It has failed base rdp")
         
         m_empty = Morphology([branch_two()])
         m_empty.simplify(epsilon=1)
@@ -212,13 +214,13 @@ class TestMorphologies(NumpyTestCase, unittest.TestCase):
         b1.attach_child(branch_two())
         m_chained = Morphology([b1])
         m_chained.simplify(epsilon=10)
-        self.assertClose(m_chained.branches[0].points, np.array([[0, 0, 0], [0, 4, 0]]), "It has failed rdp on concatenated branches")
+        self.assertClose(m_chained.branches[0].points, np.array([[0, 0, 0], [2, 4, 8]]), "It has failed rdp on concatenated branches")
         self.assertClose(m_chained.branches[1].points, np.empty((0, 3)), "It has failed rdp on concatenated branches")
 
         #test epsilon values
         m_epsilon_0 = Morphology([branch_one()])
         m_epsilon_0.simplify(epsilon=0)
-        self.assertClose(m_epsilon_0.branches[0].points, np.array([[0, 0, 0], [1, 1, 0], [0, 4, 0]]), "It has failed rdp with epsilon 0")
+        self.assertClose(m_epsilon_0.branches[0].points, np.array([[0, 0, 0], [1, 1, 0], [0, 4, 0], [0, 6, 0], [2, 4, 8]]), "It has failed rdp with epsilon 0")
         with self.assertRaises(ValueError) as context:
             m_epsilon_0.simplify(epsilon=-1)
 

--- a/tests/test_morphologies.py
+++ b/tests/test_morphologies.py
@@ -178,49 +178,58 @@ class TestMorphologies(NumpyTestCase, unittest.TestCase):
         res = m.rotate(r).root_rotate(r).translate([0, 0, 0]).collapse().close_gaps()
         self.assertEqual(m, res, "chaining calls should return self")
 
-    
     def test_simplification(self):
         def branch_one():
             return Branch(
-                np.array(
-                    [
-                        [0, 0, 0],
-                        [1, 1, 0],
-                        [0, 4, 0],
-                        [0, 6, 0],
-                        [2, 4, 8]
-                    ]
-                ),
+                np.array([[0, 0, 0], [1, 1, 0], [0, 4, 0], [0, 6, 0], [2, 4, 8]]),
                 np.array([0, 1, 2, 2, 1]),
             )
-        
+
         def branch_two():
             return Branch(
-                np.empty(
-                    (0, 3)
-                ),
+                np.empty((0, 3)),
                 np.array([]),
             )
-        
+
         m = Morphology([branch_one()])
         m.simplify(epsilon=10)
-        self.assertClose(m.branches[0].points, np.array([[0, 0, 0], [2, 4, 8]]), "It has failed base rdp")
-        
+        self.assertClose(
+            m.branches[0].points,
+            np.array([[0, 0, 0], [2, 4, 8]]),
+            "It has failed base rdp",
+        )
+
         m_empty = Morphology([branch_two()])
         m_empty.simplify(epsilon=1)
-        self.assertClose(m_empty.branches[0].points, np.empty((0, 3)), "It has failed rdp on empty branch")
-        
+        self.assertClose(
+            m_empty.branches[0].points,
+            np.empty((0, 3)),
+            "It has failed rdp on empty branch",
+        )
+
         b1 = branch_one()
         b1.attach_child(branch_two())
         m_chained = Morphology([b1])
         m_chained.simplify(epsilon=10)
-        self.assertClose(m_chained.branches[0].points, np.array([[0, 0, 0], [2, 4, 8]]), "It has failed rdp on concatenated branches")
-        self.assertClose(m_chained.branches[1].points, np.empty((0, 3)), "It has failed rdp on concatenated branches")
+        self.assertClose(
+            m_chained.branches[0].points,
+            np.array([[0, 0, 0], [2, 4, 8]]),
+            "It has failed rdp on concatenated branches",
+        )
+        self.assertClose(
+            m_chained.branches[1].points,
+            np.empty((0, 3)),
+            "It has failed rdp on concatenated branches",
+        )
 
-        #test epsilon values
+        # test epsilon values
         m_epsilon_0 = Morphology([branch_one()])
         m_epsilon_0.simplify(epsilon=0)
-        self.assertClose(m_epsilon_0.branches[0].points, np.array([[0, 0, 0], [1, 1, 0], [0, 4, 0], [0, 6, 0], [2, 4, 8]]), "It has failed rdp with epsilon 0")
+        self.assertClose(
+            m_epsilon_0.branches[0].points,
+            np.array([[0, 0, 0], [1, 1, 0], [0, 4, 0], [0, 6, 0], [2, 4, 8]]),
+            "It has failed rdp with epsilon 0",
+        )
         with self.assertRaises(ValueError) as context:
             m_epsilon_0.simplify(epsilon=-1)
 

--- a/tests/test_morphologies.py
+++ b/tests/test_morphologies.py
@@ -202,8 +202,6 @@ class TestMorphologies(NumpyTestCase, unittest.TestCase):
         
         m = Morphology([branch_one()])
         m.simplify(epsilon=10)
-        print(m.branches[0].points)
-        print(m.branches[0]._points)
         #self.assertClose(m.branches[0].points, np.array([[0, 0, 0], [0, 4, 0]]), "It has failed base rdp")
         
         m_empty = Morphology([branch_two()])
@@ -221,7 +219,8 @@ class TestMorphologies(NumpyTestCase, unittest.TestCase):
         m_epsilon_0 = Morphology([branch_one()])
         m_epsilon_0.simplify(epsilon=0)
         self.assertClose(m_epsilon_0.branches[0].points, np.array([[0, 0, 0], [1, 1, 0], [0, 4, 0]]), "It has failed rdp with epsilon 0")
-        self.assertRaises(ValueError, m.simplify(epsilon=-1))
+        with self.assertRaises(ValueError) as context:
+            m.simplify(epsilon=-1)
 
 
 class TestMorphologyLabels(NumpyTestCase, unittest.TestCase):


### PR DESCRIPTION
## Describe the work done
When a `Branch ` contains only 1 point, `branch.versor` results in `[NaN, NaN, NaN]` (because it is [0,0,0]/0).  
This caused `max_displacement` to return `NaN`.

## List which issues this resolves:
#627 
(e.g. "closes #1, #2, #3")

## Tasks

* [ ] Added tests
* [ ] Updated documentation
