### PR TITLE
Fixed ConnectivityIterator.__copy__() method

### DIFF
--- a/bsb/plotting.py
+++ b/bsb/plotting.py
@@ -211,8 +211,8 @@ def _plot_network(network, fig, cubic, swapaxes):
             continue
         pos = type.get_placement_set().load_positions()
         color = type.plotting.color if type.plotting else "black"
-        opacity=type.plotting.opacity if type.plotting else 0
-        name=type.plotting.display_name or type.name if type.plotting else "None"
+        opacity = type.plotting.opacity if type.plotting else 0
+        name = type.plotting.display_name or type.name if type.plotting else "None"
         fig.add_trace(
             go.Scatter3d(
                 x=pos[:, 0],
@@ -361,19 +361,19 @@ def plot_voxel_cloud(
 
 def get_branch_trace(branch, offset=[0.0, 0.0, 0.0], color="black", width=1.0):
     if isinstance(color, dict):
-        labels= branch.list_labels()
+        labels = branch.list_labels()
         if "soma" in labels:
             color = color["soma"]
         elif "basal_dendrites" in labels:
             color = "lightblue"
         elif "apical_dendrites" in labels:
             color = "blue"
-        elif 'aa_targets' in labels:
-            color = 'red'
-        elif 'pf_targets' in labels:
-            color = 'violet'
-        elif 'sc_targets' in labels:
-            color = 'yellow'
+        elif "aa_targets" in labels:
+            color = "red"
+        elif "pf_targets" in labels:
+            color = "violet"
+        elif "sc_targets" in labels:
+            color = "yellow"
         elif "dendrites" in labels:
             color = "blue"
         elif "ascending_axon" in labels:
@@ -385,7 +385,7 @@ def get_branch_trace(branch, offset=[0.0, 0.0, 0.0], color="black", width=1.0):
         elif "axon" in labels:
             color = color["axon"]
         else:
-            color="grey"
+            color = "grey"
     return go.Scatter3d(
         x=branch.points[:, 0],
         y=branch.points[:, 2],
@@ -469,7 +469,7 @@ def plot_morphology(
         traces.append(get_branch_trace(branch, offset, color=color, width=width))
     for trace in traces:
         fig.add_trace(trace)
-    #return fig
+    # return fig
 
 
 @_figure
@@ -606,23 +606,23 @@ def set_morphology_scene_range(scene, offset_morphologies):
     span = max(map(lambda b: b[1] - b[0], combined_bounds))
     combined_bounds[:, 1] = combined_bounds[:, 0] + span"""
 
-    min_b = np.full((len(offset_morphologies),3),0,dtype=float)
-    max_b = np.full((len(offset_morphologies),3),0,dtype=float)
-    for i,morpho in enumerate(offset_morphologies):
+    min_b = np.full((len(offset_morphologies), 3), 0, dtype=float)
+    max_b = np.full((len(offset_morphologies), 3), 0, dtype=float)
+    for i, morpho in enumerate(offset_morphologies):
         min_b[i] = morpho[1].bounds[0]
         max_b[i] = morpho[1].bounds[1]
-    #print(min_b)
-    #print(max_b)
-    x_min = np.min(min_b[:,0])
-    x_max = np.max(max_b[:,0])
-    y_min = np.min(min_b[:,1])
-    y_max = np.max(max_b[:,1])
-    z_min = np.min(min_b[:,2])
-    z_max = np.max(max_b[:,2])
-    #scene.yaxis.range =
-    #scene.zaxis.range
-    combined_bounds = [[x_min,y_min,z_min],[x_max,y_max,z_max]]
-    #combined_bounds = [[-100,-100,-100],[400,772,300]]
+    # print(min_b)
+    # print(max_b)
+    x_min = np.min(min_b[:, 0])
+    x_max = np.max(max_b[:, 0])
+    y_min = np.min(min_b[:, 1])
+    y_max = np.max(max_b[:, 1])
+    z_min = np.min(min_b[:, 2])
+    z_max = np.max(max_b[:, 2])
+    # scene.yaxis.range =
+    # scene.zaxis.range
+    combined_bounds = [[x_min, y_min, z_min], [x_max, y_max, z_max]]
+    # combined_bounds = [[-100,-100,-100],[400,772,300]]
     set_scene_range(scene, combined_bounds)
 
 

--- a/bsb/storage/interfaces.py
+++ b/bsb/storage/interfaces.py
@@ -943,9 +943,9 @@ class ConnectivityIterator:
         self._gchunks = gchunks
 
     def __copy__(self):
-        return ConnectivityIterator(
-            self._cs, self._dir, self._lchunks.copy(), self._gchunks.copy()
-        )
+        lchunks = self._lchunks.copy() if self._lchunks is not None else None
+        gchunks = self._gchunks.copy() if self._gchunks is not None else None
+        return ConnectivityIterator(self._cs, self._dir, lchunks, gchunks)
 
     def __iter__(self):
         yield from (


### PR DESCRIPTION
The original implementation of the `__copy__` method yielded an error in in the case self._lchunks and self._gchunks were NoneType.