### PR TITLE
File dependencies & csv import

### DIFF
--- a/bsb/__init__.py
+++ b/bsb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.0.0a46"
+__version__ = "4.0.0a47"
 
 import functools
 

--- a/bsb/_options.py
+++ b/bsb/_options.py
@@ -75,6 +75,7 @@ class ConfigOption(
     BsbOption,
     name="config",
     cli=("c", "config"),
+    script=("config",),
     project=("config",),
     env=("BSB_CONFIG_FILE",),
 ):

--- a/bsb/cell_types.py
+++ b/bsb/cell_types.py
@@ -67,12 +67,14 @@ class CellType:
 
     @obj_str_insert
     def __repr__(self):
-        if hasattr(self, "scaffold"):
-            cells_placed = len(self.get_placement_set())
+        try:
             placements = len(self.get_placement())
-        else:
-            cells_placed = 0
+        except Exception:
             placements = "?"
+        try:
+            cells_placed = len(self.get_placement_set())
+        except Exception:
+            cells_placed = 0
         return f"'{self.name}', {cells_placed} cells, {placements} placement strategies"
 
     def get_placement(self):

--- a/bsb/cli/commands/_projects.py
+++ b/bsb/cli/commands/_projects.py
@@ -55,21 +55,13 @@ class ProjectNewCommand(BaseCommand, name="new"):
                     "tools": {
                         "bsb": {
                             "config": output,
-                            "links": {
-                                "config": "auto",
-                                "morpho": ["sys", "morphologies.hdf5", "newer"],
-                            },
                         }
                     }
                 },
                 f,
             )
-        init_path = root / name / "__init__.py"
-        place_path = root / name / "placement.py"
-        conn_path = root / name / "connectome.py"
-        if not init_path.exists():
-            with open(init_path, "w") as f:
-                f.write("\n")
+        place_path = root / "placement.py"
+        conn_path = root / "connectome.py"
         if not place_path.exists():
             with open(place_path, "w") as f:
                 f.write("from bsb.placement import PlacementStrategy\n")

--- a/bsb/config/__init__.py
+++ b/bsb/config/__init__.py
@@ -18,6 +18,7 @@ from ._attrs import (
     attr,
     list,
     dict,
+    file,
     node,
     root,
     dynamic,
@@ -63,6 +64,7 @@ class ConfigurationModule:
     root = staticmethod(root)
     dynamic = staticmethod(dynamic)
     pluggable = staticmethod(pluggable)
+    file = staticmethod(file)
 
     walk_node_attributes = staticmethod(walk_node_attributes)
     walk_nodes = staticmethod(walk_nodes)

--- a/bsb/config/__init__.py
+++ b/bsb/config/__init__.py
@@ -199,6 +199,10 @@ def _try_parsers(content, classes, ext=None, path=None):  # pragma: nocover
 
 
 def _from_parsed(self, parser_name, tree, meta, file=None):
+    if "components" in tree:
+        from ._config import _bootstrap_components
+
+        _bootstrap_components(tree["components"])
     conf = self.Configuration(tree)
     conf._parser = parser_name
     conf._meta = meta

--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -56,7 +56,7 @@ def node(node_cls, root=False, dynamic=False, pluggable=False):
             else:
                 attrs[k] = v
     node_cls._config_attrs = attrs
-    node_cls.__post_new__ = compile_postnew(node_cls, root=root)
+    node_cls.__post_new__ = compile_postnew(node_cls)
     node_cls._config_isroot = root
     if root:
         node_cls.__post_new__ = wrap_root_postnew(node_cls.__post_new__)
@@ -138,6 +138,7 @@ def _dynamic(node_cls, class_attr, attr_name, config):
     node_cls._config_dynamic_attr = attr_name
     # Other than that compile the dynamic class like a regular node class
     node_cls = node(node_cls, dynamic=config)
+
     if config.auto_classmap or config.classmap:
         node_cls._config_dynamic_classmap = config.classmap or {}
     # This adds the parent class to its own classmap, which for subclasses happens in init

--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -1021,7 +1021,7 @@ class ConfigurationProperty(ConfigurationAttribute):
 
     def __get__(self, instance, owner):
         if instance is None:
-            return owner
+            return self
         return self.fget(instance)
 
     def __set__(self, instance, value):

--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -951,9 +951,6 @@ class ConfigurationReferenceListAttribute(ConfigurationReferenceAttribute):
             remote, remote_keys = self._prepare_self(instance, root)
         except NoReferenceAttributeSignal:  # pragma: nocover
             return None
-        if _hasattr(instance, self.attr_name):
-            remote_keys.extend(_getattr(instance, self.attr_name))
-            remote_keys = builtins.list(set(remote_keys))
         return self.resolve_reference_list(instance, remote, remote_keys)
 
     def resolve_reference_list(self, instance, remote, remote_keys):

--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -323,7 +323,10 @@ def file(**kwargs):
     """
     Create a file dependency attribute.
     """
-    return ConfigurationFileAttribute(**kwargs)
+    from ..storage import FileDependencyNode
+
+    kwargs.setdefault("type", FileDependencyNode)
+    return attr(**kwargs)
 
 
 def _setattr(instance, name, value):
@@ -1086,16 +1089,3 @@ class ConfigurationAttributeCatcher(ConfigurationAttribute):
         if hasattr(value, "__tree__"):
             value = value.__tree__()
         return value
-
-
-class ConfigurationFileAttribute(ConfigurationAttribute):
-    def __init__(self, **kwargs):
-        from ..storage._files import FileDependency
-
-        kwargs["type"] = FileDependency
-        super().__init__(**kwargs)
-
-    def __boot__(self, instance, scaffold):
-        file = getattr(instance, self.attr_name)
-        file.file_store = scaffold.files
-        file.update()

--- a/bsb/config/_config.py
+++ b/bsb/config/_config.py
@@ -1,12 +1,14 @@
-from . import attr, dict, root, node, types
+from typing import TYPE_CHECKING
+
+from . import attr, list, dict, root, node, types, provide as config_property
 from ..cell_types import CellType
-from ._attrs import _boot_nodes
+from ._attrs import _boot_nodes, file as file_attr
 from ..placement import PlacementStrategy
 from ..storage.interfaces import StorageNode
 from ..connectivity import ConnectionStrategy
 from ..simulation.simulation import Simulation
 from ..postprocessing import PostProcessingHook
-from ..exceptions import UnmanagedPartitionError
+from ..exceptions import UnmanagedPartitionError, CodeImportError
 from .._util import merge_dicts
 from ..topology import (
     get_partitions,
@@ -16,6 +18,11 @@ from ..topology import (
 )
 import builtins
 import numpy as np
+import os
+import sys
+
+if TYPE_CHECKING:
+    from ..storage._files import FileDependency
 
 
 @node
@@ -39,6 +46,53 @@ class NetworkNode:
         self.chunk_size = np.array(self.chunk_size)
 
 
+@node
+class FileDependencyNode:
+    file: "FileDependency" = file_attr()
+
+    def __init__(self, value=None, **kwargs):
+        if value is not None:
+            self.file = value
+
+    def __inv__(self):
+        if self._config_pos_init:
+            return self.file._given_source
+        else:
+            return self.__tree__()
+
+
+@node
+class CodeDependencyNode(FileDependencyNode):
+    module: str = attr(type=str)
+
+    @config_property
+    def file(self):
+        from ..storage._files import FileDependency
+
+        return FileDependency(self.module.replace(".", os.sep) + ".py")
+
+    def __init__(self, module=None, **kwargs):
+        super().__init__(**kwargs)
+        if module is not None:
+            self.module = module
+
+    def load_object(self):
+        import importlib.util
+        import sys
+
+        sys.path.append(os.getcwd())
+        try:
+            with self.file.provide_locally() as path:
+                spec = importlib.util.spec_from_file_location(self.module, path)
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[self.module] = module
+                spec.loader.exec_module(module)
+        finally:
+            tmp = builtins.list(reversed(sys.path))
+            tmp.remove(os.getcwd())
+            sys.path = builtins.list(reversed(tmp))
+
+
 @root
 class Configuration:
     """
@@ -46,6 +100,7 @@ class Configuration:
     """
 
     name = attr()
+    components = list(type=CodeDependencyNode)
     storage = attr(type=StorageNode, required=True)
     network = attr(type=NetworkNode, required=True)
     regions = dict(type=Region)
@@ -101,3 +156,10 @@ class Configuration:
 
     def __repr__(self):
         return f"{type(self).__qualname__}({self})"
+
+
+def _bootstrap_components(components, file_store=None):
+    for component in components:
+        component_node = CodeDependencyNode(component)
+        component_node.file_store = file_store
+        component_node.load_object()

--- a/bsb/config/_config.py
+++ b/bsb/config/_config.py
@@ -87,7 +87,7 @@ class Configuration:
         # If there are any partitions not part of the topology, raise an error
         if unmanaged := set(self.partitions.values()) - get_partitions([topology]):
             p = "', '".join(p.name for p in unmanaged)
-            r = scaffold.configuration.regions.add(
+            r = scaffold.regions.add(
                 "__unmanaged__", RegionGroup(children=builtins.list(unmanaged))
             )
             topology.children.append(r)

--- a/bsb/config/_make.py
+++ b/bsb/config/_make.py
@@ -496,6 +496,11 @@ def make_dictable(node_cls):
 
 def make_tree(node_cls):
     def get_tree(instance):
+        if hasattr(instance, "__inv__") and not getattr(instance, "_config_inv", None):
+            instance._config_inv = True
+            inv = instance.__inv__()
+            instance._config_inv = False
+            return inv
         attrs = _get_class_config_attrs(instance.__class__)
         catch_attrs = [a for a in attrs.values() if hasattr(a, "__catch__")]
         tree = {}

--- a/bsb/config/_make.py
+++ b/bsb/config/_make.py
@@ -82,6 +82,7 @@ def make_metaclass(cls):
                         + f": e.g. 'def __init__{sig}'"
                     ) from None
                 else:
+                    instance._config_pos_init = bool(len(args))
                     instance.__init__(*args, **kwargs)
             return instance
 

--- a/bsb/connectivity/__init__.py
+++ b/bsb/connectivity/__init__.py
@@ -1,4 +1,5 @@
 from .strategy import ConnectionStrategy
 from .detailed import *
 from .general import *
+from .import_ import CsvImportConnectivity
 from .detailed.fiber_intersection import FiberTransform, QuiverTransform

--- a/bsb/connectivity/import_.py
+++ b/bsb/connectivity/import_.py
@@ -7,13 +7,13 @@ from collections import defaultdict
 import psutil
 import numpy as np
 from tqdm import tqdm
-
+from ..exceptions import ConfigurationError
 from .strategy import ConnectionStrategy
 from ..storage import Chunk
-from ..exceptions import ConfigurationError
 from .. import config
 from ..config import refs
 from ..mixins import NotParallel
+from ..storage.interfaces import PlacementSet
 
 
 @config.node
@@ -30,145 +30,120 @@ class ImportConnectivity(NotParallel, ConnectionStrategy, abc.ABC, classmap_entr
     def cache(self, value):
         self.source.cache = bool(value)
 
-    def connect(self, chunk, indicators):
-        self.parse_source(indicators)
+    def connect(self, pre, post):
+        self.parse_source(pre, post)
 
     @abc.abstractmethod
-    def parse_source(self, indicators):
+    def parse_source(self, pre, post):
         pass
 
 
 @config.node
 class CsvImportConnectivity(ImportConnectivity):
-    x_header = config.attr(default="x")
-    y_header = config.attr(default="y")
-    z_header = config.attr(default="z")
-    type_header = config.attr()
+    pre_header = config.attr(default="pre")
+    post_header = config.attr(default="post")
+    mapping_key = config.attr()
     delimiter = config.attr(default=",")
     progress_bar = config.attr(type=bool, default=True)
 
     def __boot__(self):
-        if not self.type_header and len(self.get_considered_cell_types()) > 1:
-            raise ConfigurationError(
-                "Must set `type_header` to import multiple cell types from single CSV."
+        if (
+            len(self.presynaptic.cell_types) != 1
+            or len(self.postsynaptic.cell_types) != 1
+        ):
+            raise NotImplementedError(
+                "CsvImportConnectivity is strictly from 1 cell type to 1 other cell type"
             )
 
-    def parse_source(self, indicators):
-        self._reset_cache()
-        chunk_size = np.array(self.scaffold.network.chunk_size)
+    def parse_source(self, pre, post):
+        pre = next(iter(pre.placement.values()))
+        post = next(iter(post.placement.values()))
+        if self.mapping_key:
+
+            def make_maps(pre_chunks, post_chunks):
+                return self._passover(pre, pre_chunks, post, post_chunks)
+
+            passover_iter = self._load_balance(pre, post)
+        else:
+
+            def make_maps(pre_chunks, post_chunks):
+                def flush(pre_block, post_block, other_block):
+                    with pre.chunk_context(pre_chunks):
+                        with post.chunk_context(post_chunks):
+                            self.connect_cells(pre, post, pre_block, post_block)
+
+                return lambda x: x, lambda x: x, flush
+
+            passover_iter = ((pre.get_all_chunks(), post.get_all_chunks()),)
+        if self.progress_bar:
+            passover_iter = tqdm(
+                passover_iter, desc="processed", unit="passes", total=len(passover_iter)
+            )
         with self.source.provide_stream() as (fp, encoding):
             text = io.TextIOWrapper(fp, encoding=encoding, newline="")
             reader = csv.reader(text)
             headers = [h.strip().lower() for h in next(reader)]
-            type_col = headers.index(self.type_header) if self.type_header else None
-            coord_cols = [
-                *map(headers.index, (self.x_header, self.y_header, self.z_header))
-            ]
-            other_cols = [
-                r for r in range(len(headers)) if r not in coord_cols and r != type_col
-            ]
+            try:
+                cols = [*map(headers.index, (self.pre_header, self.post_header))]
+            except ValueError:
+                raise ConfigurationError(
+                    f"'{self.pre_header}' or '{self.post_header}' not found in "
+                    f"'{self.source.file.uri}' column headers {headers}."
+                )
+            other_cols = [r for r in range(len(headers)) if r not in cols]
             self._other_colnames = [headers[c] for c in other_cols]
-            cts = self.get_considered_cell_types()
-            if len(cts) == 1:
-                name = cts[0].name
-            i = 0
-            if self.progress_bar:
-                reader = tqdm(reader, desc="imported", unit=" lines")
-            for line in reader:
-                ct_cache = self._cache[line[type_col] if type_col is not None else name]
-                coords = [_safe_float(line[c]) for c in coord_cols]
-                others = [_safe_float(line[c]) for c in other_cols]
-                cache = ct_cache[tuple(coords // chunk_size)]
-                cache[0].append(coords)
-                cache[1].append(others)
+            for pre_chunks, post_chunks in passover_iter:
+                mappers = make_maps(pre_chunks, post_chunks)
+                flush = mappers[2]
+                i = 0
+                if self.progress_bar:
+                    reader = tqdm(reader, desc="imported", unit=" lines")
+                pre_block = []
+                post_block = []
+                other_block = []
+                for line in reader:
+                    ids = [map_(_safe_int(line[c])) for c, map_ in zip(cols, mappers)]
+                    other = [_safe_float(line[c]) for c in other_cols]
+                    if ids[0] > -1 and ids[1] > -1:
+                        pre_block.append(ids[0])
+                        post_block.append(ids[1])
+                        other_block.append(other)
+                    if i % 100 == 0:
+                        est_memsize = (len(other_cols) + 2) * i * 24
+                        av_mem = psutil.virtual_memory().available
+                        if est_memsize > av_mem / 10:
+                            flush(pre_block, post_block, other_block)
+                            pre_block = []
+                            post_block = []
+                            other_block = []
+                    i += 1
+                flush(pre_block, post_block, other_block)
 
-                if i % 100 == 0:
-                    est_memsize = (len(others) + 3) * i * 8
-                    av_mem = psutil.virtual_memory().available
-                    if est_memsize > av_mem / 10:
-                        print(
-                            "FLUSHING, AVAILABLE MEM:",
-                        )
-                        self._flush(indicators)
-                i += 1
-            self._flush(indicators)
+    def _passover(self, pre: PlacementSet, pre_chunks, post: PlacementSet, post_chunks):
+        with pre.chunk_context(pre_chunks):
+            data = pre.load_additional(self.mapping_key)
+            pre_map = {m: i for i, m in enumerate(data)}.get
+        with pre.chunk_context(pre_chunks):
+            data = post.load_additional(self.mapping_key)
+            post_map = {m: i for i, m in enumerate(data)}.get
 
-    def get_considered_cell_types(self):
-        return self.cell_types or self.scaffold.cell_types.values()
+        def flush(pre_block, post_block, other_block):
+            with pre.chunk_context(pre_chunks):
+                with post.chunk_context(post_chunks):
+                    self.connect_cells(pre, post, pre_block, post_block)
 
-    def _reset_cache(self):
-        self._cache = {
-            ct.name: defaultdict(lambda: [[], []])
-            for ct in self.get_considered_cell_types()
-        }
+        return pre_map, post_map, flush
 
-    def _flush(self, indicators):
-        cell_types = self.get_considered_cell_types()
-        iter = zip(cell_types, self._cache.values())
-        if self.progress_bar:
-            iter = tqdm(
-                iter,
-                desc="cell types",
-                total=len(cell_types),
+    def _load_balance(self, pre, post, pre_chunks=None, post_chunks=None):
+        meminfo = psutil.virtual_memory()
+        # Div 16 for array copying safety measures
+        if (len(pre) + len(post)) * 24 < meminfo.available / 16:
+            return ((pre.get_all_chunks(), post.get_all_chunks()),)
+        else:
+            raise NotImplementedError(
+                "Too many cells to fit into memory. "
+                "Piecewise import not implemented yet. Open a GitHub issue."
             )
-        for ct, chunked_cache in iter:
-            inner = ((Chunk(c, None), data) for c, data in chunked_cache.items())
-            if self.progress_bar:
-                inner = tqdm(
-                    inner,
-                    desc="saved",
-                    total=len(chunked_cache),
-                    bar_format="{l_bar}{bar} [ {n_fmt}/{total_fmt} time left: {remaining}, time spent: {elapsed}]",
-                )
-            for chunk, data in inner:
-                print("Saving data in", chunk, chunk.id)
-                additional = np.array(data[1], dtype=float).T
-                self.place_cells(
-                    indicators[ct.name],
-                    np.array(data[0]),
-                    chunk,
-                    additional={
-                        name: col for name, col in zip(self._other_colnames, additional)
-                    },
-                )
-        self._reset_cache()
-
-    # @abc.abstractmethod
-    # def _place_from_csv(self):
-    #     src = self.get_external_source()
-    #     if not self.check_external_source():
-    #         raise MissingSourceError(f"Missing source file '{src}' for `{self.name}`.")
-    #     # If the `map_header` is given, we should store all data in that column
-    #     # as references that the user will need later on to map their external
-    #     # data to our generated data
-    #     should_map = self.map_header is not None
-    #     # Read the CSV file's first line to get the column names
-    #     with open(src, "r") as f:
-    #         headers = f.readline().split(self.delimiter)
-    #     # Search for the x, y, z headers
-    #     usecols = list(map(headers.index, (self.x_header, self.y_header, self.z_header)))
-    #     if should_map:
-    #         # Optionally, search for the map header
-    #         usecols.append(headers.index(self.map_header))
-    #     # Read the entire csv, skipping the headers and only the cols we need.
-    #     data = np.loadtxt(
-    #         src,
-    #         usecols=usecols,
-    #         skiprows=1,
-    #         delimiter=self.delimiter,
-    #     )
-    #     if should_map:
-    #         # If a map column was appended, slice it off
-    #         external_map = data[:, -1]
-    #         data = data[:, :-1]
-    #         # Check for garbage
-    #         duplicates = len(external_map) - len(np.unique(external_map))
-    #         if duplicates:
-    #             raise SourceQualityError(f"{duplicates} duplicates in source '{src}'")
-    #         # And store it as appendix dataset
-    #         self.scaffold.append_dset(self.name + "_ext_map", external_map)
-    #     # Store the CSV positions in the scaffold
-    #     self.scaffold.place_cells(self.cell_type, None, data)
 
 
 def _safe_float(value: typing.Any) -> float:
@@ -176,3 +151,10 @@ def _safe_float(value: typing.Any) -> float:
         return float(value)
     except ValueError:
         return float("nan")
+
+
+def _safe_int(value: typing.Any) -> int:
+    try:
+        return int(float(value))
+    except ValueError:
+        return -1

--- a/bsb/connectivity/import_.py
+++ b/bsb/connectivity/import_.py
@@ -1,0 +1,178 @@
+import abc
+import csv
+import io
+import typing
+from collections import defaultdict
+
+import psutil
+import numpy as np
+from tqdm import tqdm
+
+from .strategy import ConnectionStrategy
+from ..storage import Chunk
+from ..exceptions import ConfigurationError
+from .. import config
+from ..config import refs
+from ..mixins import NotParallel
+
+
+@config.node
+class ImportConnectivity(NotParallel, ConnectionStrategy, abc.ABC, classmap_entry=None):
+    source = config.file(required=True)
+    cell_types = config.reflist(refs.cell_type_ref, required=False)
+    partitions = config.reflist(refs.partition_ref, required=False)
+
+    @config.property(default=False)
+    def cache(self):
+        return self.source.cache
+
+    @cache.setter
+    def cache(self, value):
+        self.source.cache = bool(value)
+
+    def connect(self, chunk, indicators):
+        self.parse_source(indicators)
+
+    @abc.abstractmethod
+    def parse_source(self, indicators):
+        pass
+
+
+@config.node
+class CsvImportConnectivity(ImportConnectivity):
+    x_header = config.attr(default="x")
+    y_header = config.attr(default="y")
+    z_header = config.attr(default="z")
+    type_header = config.attr()
+    delimiter = config.attr(default=",")
+    progress_bar = config.attr(type=bool, default=True)
+
+    def __boot__(self):
+        if not self.type_header and len(self.get_considered_cell_types()) > 1:
+            raise ConfigurationError(
+                "Must set `type_header` to import multiple cell types from single CSV."
+            )
+
+    def parse_source(self, indicators):
+        self._reset_cache()
+        chunk_size = np.array(self.scaffold.network.chunk_size)
+        with self.source.provide_stream() as (fp, encoding):
+            text = io.TextIOWrapper(fp, encoding=encoding, newline="")
+            reader = csv.reader(text)
+            headers = [h.strip().lower() for h in next(reader)]
+            type_col = headers.index(self.type_header) if self.type_header else None
+            coord_cols = [
+                *map(headers.index, (self.x_header, self.y_header, self.z_header))
+            ]
+            other_cols = [
+                r for r in range(len(headers)) if r not in coord_cols and r != type_col
+            ]
+            self._other_colnames = [headers[c] for c in other_cols]
+            cts = self.get_considered_cell_types()
+            if len(cts) == 1:
+                name = cts[0].name
+            i = 0
+            if self.progress_bar:
+                reader = tqdm(reader, desc="imported", unit=" lines")
+            for line in reader:
+                ct_cache = self._cache[line[type_col] if type_col is not None else name]
+                coords = [_safe_float(line[c]) for c in coord_cols]
+                others = [_safe_float(line[c]) for c in other_cols]
+                cache = ct_cache[tuple(coords // chunk_size)]
+                cache[0].append(coords)
+                cache[1].append(others)
+
+                if i % 100 == 0:
+                    est_memsize = (len(others) + 3) * i * 8
+                    av_mem = psutil.virtual_memory().available
+                    if est_memsize > av_mem / 10:
+                        print(
+                            "FLUSHING, AVAILABLE MEM:",
+                        )
+                        self._flush(indicators)
+                i += 1
+            self._flush(indicators)
+
+    def get_considered_cell_types(self):
+        return self.cell_types or self.scaffold.cell_types.values()
+
+    def _reset_cache(self):
+        self._cache = {
+            ct.name: defaultdict(lambda: [[], []])
+            for ct in self.get_considered_cell_types()
+        }
+
+    def _flush(self, indicators):
+        cell_types = self.get_considered_cell_types()
+        iter = zip(cell_types, self._cache.values())
+        if self.progress_bar:
+            iter = tqdm(
+                iter,
+                desc="cell types",
+                total=len(cell_types),
+            )
+        for ct, chunked_cache in iter:
+            inner = ((Chunk(c, None), data) for c, data in chunked_cache.items())
+            if self.progress_bar:
+                inner = tqdm(
+                    inner,
+                    desc="saved",
+                    total=len(chunked_cache),
+                    bar_format="{l_bar}{bar} [ {n_fmt}/{total_fmt} time left: {remaining}, time spent: {elapsed}]",
+                )
+            for chunk, data in inner:
+                print("Saving data in", chunk, chunk.id)
+                additional = np.array(data[1], dtype=float).T
+                self.place_cells(
+                    indicators[ct.name],
+                    np.array(data[0]),
+                    chunk,
+                    additional={
+                        name: col for name, col in zip(self._other_colnames, additional)
+                    },
+                )
+        self._reset_cache()
+
+    # @abc.abstractmethod
+    # def _place_from_csv(self):
+    #     src = self.get_external_source()
+    #     if not self.check_external_source():
+    #         raise MissingSourceError(f"Missing source file '{src}' for `{self.name}`.")
+    #     # If the `map_header` is given, we should store all data in that column
+    #     # as references that the user will need later on to map their external
+    #     # data to our generated data
+    #     should_map = self.map_header is not None
+    #     # Read the CSV file's first line to get the column names
+    #     with open(src, "r") as f:
+    #         headers = f.readline().split(self.delimiter)
+    #     # Search for the x, y, z headers
+    #     usecols = list(map(headers.index, (self.x_header, self.y_header, self.z_header)))
+    #     if should_map:
+    #         # Optionally, search for the map header
+    #         usecols.append(headers.index(self.map_header))
+    #     # Read the entire csv, skipping the headers and only the cols we need.
+    #     data = np.loadtxt(
+    #         src,
+    #         usecols=usecols,
+    #         skiprows=1,
+    #         delimiter=self.delimiter,
+    #     )
+    #     if should_map:
+    #         # If a map column was appended, slice it off
+    #         external_map = data[:, -1]
+    #         data = data[:, :-1]
+    #         # Check for garbage
+    #         duplicates = len(external_map) - len(np.unique(external_map))
+    #         if duplicates:
+    #             raise SourceQualityError(f"{duplicates} duplicates in source '{src}'")
+    #         # And store it as appendix dataset
+    #         self.scaffold.append_dset(self.name + "_ext_map", external_map)
+    #     # Store the CSV positions in the scaffold
+    #     self.scaffold.place_cells(self.cell_type, None, data)
+
+
+def _safe_float(value: typing.Any) -> float:
+    try:
+        return float(value)
+    except ValueError:
+        return float("nan")

--- a/bsb/connectivity/strategy.py
+++ b/bsb/connectivity/strategy.py
@@ -34,7 +34,10 @@ class HemitypeCollection:
         }
 
     def __getattr__(self, attr):
-        return self.placement[attr]
+        if attr == "placement":
+            return type(self).placement.__get__(self)
+        else:
+            return self.placement[attr]
 
     def __getitem__(self, item):
         return self.placement[item]

--- a/bsb/connectivity/strategy.py
+++ b/bsb/connectivity/strategy.py
@@ -84,9 +84,9 @@ class ConnectionStrategy(abc.ABC, SortableByAfter):
     def connect(self, presyn_collection, postsyn_collection):
         pass
 
-    def _get_connect_args_from_job(self, chunk, roi):
-        pre = HemitypeCollection(self.presynaptic, [chunk])
-        post = HemitypeCollection(self.postsynaptic, roi)
+    def _get_connect_args_from_job(self, pre_roi, post_roi):
+        pre = HemitypeCollection(self.presynaptic, pre_roi)
+        post = HemitypeCollection(self.postsynaptic, post_roi)
         return pre, post
 
     def connect_cells(self, pre_set, post_set, src_locs, dest_locs, tag=None):
@@ -128,7 +128,7 @@ class ConnectionStrategy(abc.ABC, SortableByAfter):
                 f"in '{self.name}'."
             )
         for chunk, roi in rois.items():
-            job = pool.queue_connectivity(self, chunk, roi, deps=deps)
+            job = pool.queue_connectivity(self, [chunk], roi, deps=deps)
             self._queued_jobs.append(job)
         report(f"Queued {len(self._queued_jobs)} jobs for {self.name}", level=2)
 

--- a/bsb/core.py
+++ b/bsb/core.py
@@ -722,15 +722,17 @@ class Scaffold:
             try:
                 cfg = storage.load_active_config()
             except Exception:
-                return None
+                import bsb.options
+
+                path = bsb.options.config
             else:
                 path = cfg._meta.get("path", None)
-                if path and os.path.exists(path):
-                    with open(path, "r") as f:
-                        cfg = bsb.config.from_file(f)
-                        return cfg
-                else:
-                    return None
+            if path and os.path.exists(path):
+                with open(path, "r") as f:
+                    cfg = bsb.config.from_file(f)
+                    return cfg
+            else:
+                return None
         elif link.type != "sys":
             raise ScaffoldError("Configuration link can only be 'auto' or 'sys' link.")
         elif link.exists():

--- a/bsb/core.py
+++ b/bsb/core.py
@@ -70,6 +70,25 @@ def _config_property(name):
     return prop.setter(fset)
 
 
+def _get_linked_config(storage=None):
+    import bsb.config
+
+    try:
+        cfg = storage.load_active_config()
+    except Exception:
+        import bsb.options
+
+        path = bsb.options.config
+    else:
+        path = cfg._meta.get("path", None)
+    if path and os.path.exists(path):
+        with open(path, "r") as f:
+            cfg = bsb.config.from_file(f)
+            return cfg
+    else:
+        return None
+
+
 class Scaffold:
     """
 
@@ -129,7 +148,7 @@ class Scaffold:
         if config is None:
             # No config given, check for linked configs, or stored configs, otherwise
             # make default config.
-            linked = self._get_linked_config(storage)
+            linked = _get_linked_config(storage)
             if linked:
                 report(f"Pulling configuration from linked {linked}.", level=2)
                 config = linked

--- a/bsb/core.py
+++ b/bsb/core.py
@@ -431,7 +431,7 @@ class Scaffold:
         """
         if chunk is None:
             chunk = Chunk([0, 0, 0], self.network.chunk_size)
-        if np.any(np.isnan(chunk.dimensions)):
+        if hasattr(chunk, "dimensions") and np.any(np.isnan(chunk.dimensions)):
             chunk.dimensions = self.network.chunk_size
         self.get_placement_set(cell_type).append_data(
             chunk,

--- a/bsb/core.py
+++ b/bsb/core.py
@@ -2,6 +2,7 @@ import time
 import os
 import itertools
 import typing
+import numpy as np
 
 from .placement import PlacementStrategy
 from .connectivity import ConnectionStrategy
@@ -430,6 +431,8 @@ class Scaffold:
         """
         if chunk is None:
             chunk = Chunk([0, 0, 0], self.network.chunk_size)
+        if np.any(np.isnan(chunk.dimensions)):
+            chunk.dimensions = self.network.chunk_size
         self.get_placement_set(cell_type).append_data(
             chunk,
             positions=positions,

--- a/bsb/exceptions.py
+++ b/bsb/exceptions.py
@@ -3,7 +3,7 @@ from errr import make_tree as _t, exception as _e
 _t(
     globals(),
     ScaffoldError=_e(
-        SpatialDimensionError=_e(),
+        CodeImportError=_e(),
         CLIError=_e(
             CommandError=_e(),
             ConfigTemplateNotFoundError=_e("template", "path"),

--- a/bsb/exceptions.py
+++ b/bsb/exceptions.py
@@ -13,7 +13,7 @@ _t(
         ConfigurationError=_e(
             ConfigurationFormatError=_e(),
             DynamicClassError=_e(
-                DynamicClassNotFoundError=_e(),
+                DynamicObjectNotFoundError=_e(),
                 DynamicClassInheritanceError=_e(),
                 ClassMapMissingError=_e(),
             ),

--- a/bsb/mixins.py
+++ b/bsb/mixins.py
@@ -1,5 +1,3 @@
-from .connectivity import ConnectionStrategy
-from .placement import PlacementStrategy
 from .reporting import report
 from .storage import Chunk
 from . import _util as _gutil
@@ -47,6 +45,9 @@ def _raise_na(*args, **kwargs):
 
 class NotParallel:
     def __init_subclass__(cls, **kwargs):
+        from .connectivity import ConnectionStrategy
+        from .placement import PlacementStrategy
+
         super().__init_subclass__(**kwargs)
         if PlacementStrategy in cls.__mro__:
             cls.queue = _queue_placement

--- a/bsb/morphologies/__init__.py
+++ b/bsb/morphologies/__init__.py
@@ -1074,10 +1074,12 @@ class Branch:
 
         .. warning::
 
-           Constructing a kd-tree takes time and should only be used for repeated querying.
+           Constructing a kd-tree takes time and should only be used for repeat queries.
 
         """
-        return cKDTree(self._points)
+        import scipy.spatial
+
+        return scipy.spatial.cKDTree(self._points)
 
     @property
     def point_vectors(self):

--- a/bsb/placement/__init__.py
+++ b/bsb/placement/__init__.py
@@ -2,8 +2,8 @@ from .strategy import (
     PlacementStrategy,
     FixedPositions,
     Entities,
-    ExternalPlacement,
 )
+from .import_ import ImportPlacement, CsvImportPlacement
 from .arrays import ParallelArrayPlacement
 from .particle import ParticlePlacement, RandomPlacement
 from .satellite import Satellite

--- a/bsb/placement/import_.py
+++ b/bsb/placement/import_.py
@@ -1,0 +1,151 @@
+import abc
+import csv
+import io
+from collections import defaultdict
+
+import psutil
+import numpy as np
+
+from .strategy import PlacementStrategy
+from ..storage import Chunk
+from ..exceptions import ConfigurationError
+from .. import config
+from ..config import refs
+from ..mixins import NotParallel
+
+
+@config.node
+class ImportPlacement(NotParallel, PlacementStrategy, abc.ABC, classmap_entry=None):
+    source = config.file(required=True)
+    cell_types = config.reflist(refs.cell_type_ref, required=False)
+    partitions = config.reflist(refs.partition_ref, required=False)
+
+    @config.property(default=False)
+    def cache(self):
+        return self.source.cache
+
+    @cache.setter
+    def cache(self, value):
+        self.source.cache = bool(value)
+
+    def place(self, chunk, indicators):
+        self.parse_source(indicators)
+
+    @abc.abstractmethod
+    def parse_source(self, indicators):
+        pass
+
+
+@config.node
+class CsvImportPlacement(ImportPlacement):
+    x_header = config.attr(default="x")
+    y_header = config.attr(default="y")
+    z_header = config.attr(default="z")
+    type_header = config.attr()
+    delimiter = config.attr(default=",")
+
+    def __boot__(self):
+        if not self.type_header and len(self.get_considered_cell_types()) > 1:
+            raise ConfigurationError(
+                "Must set `type_header` to import multiple cell types from single CSV."
+            )
+
+    def parse_source(self, indicators):
+        self._reset_cache()
+        chunk_size = self.scaffold.network.chunk_size
+        print(psutil.virtual_memory())
+        with self.source.provide_stream() as (fp, encoding):
+            text = io.TextIOWrapper(fp, encoding=encoding, newline="")
+            reader = csv.reader(text)
+            headers = [h.strip().lower() for h in next(reader)]
+            type_col = headers.index(self.type_header) if self.type_header else None
+            coord_cols = [
+                *map(headers.index, (self.x_header, self.y_header, self.z_header))
+            ]
+            other_cols = [
+                r for r in range(len(headers)) if r not in coord_cols and r != type_col
+            ]
+            self._other_colnames = [headers[c] for c in other_cols]
+            i = 0
+            for line in reader:
+                ct_cache = self._cache[line[type_col] if type_col is not None else 0]
+                coords = [line[c] for c in coord_cols]
+                others = [line[c] for c in other_cols]
+                cache = ct_cache[tuple(coords // chunk_size)]
+                cache[0].append(coords)
+                cache[1].append(others)
+
+                if i % 100000 == 0:
+                    est_memsize = (len(cache[1][0]) + 3) * len(cache[0]) * 8
+                    av_mem = psutil.virtual_memory().available
+                    if est_memsize > av_mem / 10:
+                        print(
+                            "FLUSHING, AVAILABLE MEM:",
+                        )
+                        self._flush()
+                i += 1
+            self._flush()
+
+    def get_considered_cell_types(self):
+        return self.cell_types or self.scaffold.cell_types.values()
+
+    def _reset_cache(self):
+        self._cache = {
+            ct.name: defaultdict(lambda: [[], []])
+            for ct in self.get_considered_cell_types()
+        }
+
+    def _flush(self, indicators):
+        for ct, chunked_cache in zip(
+            self.get_considered_cell_types(), self._cache.values()
+        ):
+            for chunk, data in (
+                (Chunk(c, None), data) for c, data in chunked_cache.items()
+            ):
+                additional = np.array(data[1], dtype=float)
+                self.place_cells(
+                    indicators[ct],
+                    np.array(data[0]),
+                    chunk,
+                    additional={
+                        name: col for name, col in zip(self._other_colnames, data[1])
+                    },
+                )
+        self._reset_cache()
+
+    # @abc.abstractmethod
+    # def _place_from_csv(self):
+    #     src = self.get_external_source()
+    #     if not self.check_external_source():
+    #         raise MissingSourceError(f"Missing source file '{src}' for `{self.name}`.")
+    #     # If the `map_header` is given, we should store all data in that column
+    #     # as references that the user will need later on to map their external
+    #     # data to our generated data
+    #     should_map = self.map_header is not None
+    #     # Read the CSV file's first line to get the column names
+    #     with open(src, "r") as f:
+    #         headers = f.readline().split(self.delimiter)
+    #     # Search for the x, y, z headers
+    #     usecols = list(map(headers.index, (self.x_header, self.y_header, self.z_header)))
+    #     if should_map:
+    #         # Optionally, search for the map header
+    #         usecols.append(headers.index(self.map_header))
+    #     # Read the entire csv, skipping the headers and only the cols we need.
+    #     data = np.loadtxt(
+    #         src,
+    #         usecols=usecols,
+    #         skiprows=1,
+    #         delimiter=self.delimiter,
+    #     )
+    #     if should_map:
+    #         # If a map column was appended, slice it off
+    #         external_map = data[:, -1]
+    #         data = data[:, :-1]
+    #         # Check for garbage
+    #         duplicates = len(external_map) - len(np.unique(external_map))
+    #         if duplicates:
+    #             raise SourceQualityError(f"{duplicates} duplicates in source '{src}'")
+    #         # And store it as appendix dataset
+    #         self.scaffold.append_dset(self.name + "_ext_map", external_map)
+    #     # Store the CSV positions in the scaffold
+    #     self.scaffold.place_cells(self.cell_type, None, data)

--- a/bsb/placement/import_.py
+++ b/bsb/placement/import_.py
@@ -82,7 +82,7 @@ class CsvImportPlacement(ImportPlacement):
                 cache[0].append(coords)
                 cache[1].append(others)
 
-                if i % 100 == 0:
+                if i % 10000 == 0:
                     est_memsize = (len(others) + 3) * i * 8
                     av_mem = psutil.virtual_memory().available
                     if est_memsize > av_mem / 10:

--- a/bsb/placement/particle.py
+++ b/bsb/placement/particle.py
@@ -524,9 +524,7 @@ def get_particles_trace(particles, dimensions=3, axes={"x": 0, "y": 1, "z": 2}, 
     }
     trace_kwargs.update(kwargs)
     if dimensions > 3:
-        raise SpatialDimensionError(
-            "Maximum 3 dimensional plots. Unless you have mutant eyes."
-        )
+        raise ValueError("Maximum 3 dimensional plots. Unless you have mutant eyes.")
     elif dimensions == 3:
         return go.Scatter3d(
             x=list(map(lambda p: p.position[axes["x"]], particles)),

--- a/bsb/placement/strategy.py
+++ b/bsb/placement/strategy.py
@@ -63,7 +63,9 @@ class PlacementStrategy(abc.ABC, SortableByAfter):
         """
         pass
 
-    def place_cells(self, indicator, positions, chunk):
+    def place_cells(self, indicator, positions, chunk, additional=None):
+        if additional is None:
+            additional = {}
         if self.distribute._has_mdistr() or indicator.use_morphologies():
             try:
                 morphologies, rotations = self.distribute._specials(
@@ -81,7 +83,9 @@ class PlacementStrategy(abc.ABC, SortableByAfter):
             morphologies, rotations = None, None
 
         distr = self.distribute._curry(self.partitions, indicator, positions)
-        additional = {prop: distr(prop) for prop in self.distribute.properties.keys()}
+        additional.update(
+            {prop: distr(prop) for prop in self.distribute.properties.keys()}
+        )
         self.scaffold.place_cells(
             indicator.cell_type,
             positions=positions,
@@ -189,78 +193,3 @@ class Entities(PlacementStrategy):
             # Guess total number, not chunk number, as entities bypass chunking.
             n = indicator.guess()
             self.scaffold.create_entities(cell_type, n)
-
-
-class ExternalPlacement(PlacementStrategy):
-    required = ["source"]
-    casts = {"format": str, "warn_missing": bool}
-    defaults = {
-        "format": "csv",
-        "x_header": "x",
-        "y_header": "y",
-        "z_header": "z",
-        "map_header": None,
-        "warn_missing": True,
-        "delimiter": ",",
-    }
-
-    has_external_source = True
-
-    def check_external_source(self):
-        return os.path.exists(self.source)
-
-    def get_external_source(self):
-        return self.source
-
-    def validate(self):
-        if self.warn_missing and not self.check_external_source():
-            src = self.get_external_source()
-            warn(f"Missing external source '{src}' for '{self.name}'")
-
-    def place(self):
-        if self.format == "csv":
-            return self._place_from_csv()
-
-    def get_placement_count(self):
-        import csv
-
-        file = self.get_external_source()
-        f = csv.reader(open(file, "r"))
-        csv_lines = sum(1 for line in f)
-        return csv_lines - 1
-
-    def _place_from_csv(self):
-        src = self.get_external_source()
-        if not self.check_external_source():
-            raise MissingSourceError(f"Missing source file '{src}' for `{self.name}`.")
-        # If the `map_header` is given, we should store all data in that column
-        # as references that the user will need later on to map their external
-        # data to our generated data
-        should_map = self.map_header is not None
-        # Read the CSV file's first line to get the column names
-        with open(src, "r") as f:
-            headers = f.readline().split(self.delimiter)
-        # Search for the x, y, z headers
-        usecols = list(map(headers.index, (self.x_header, self.y_header, self.z_header)))
-        if should_map:
-            # Optionally, search for the map header
-            usecols.append(headers.index(self.map_header))
-        # Read the entire csv, skipping the headers and only the cols we need.
-        data = np.loadtxt(
-            src,
-            usecols=usecols,
-            skiprows=1,
-            delimiter=self.delimiter,
-        )
-        if should_map:
-            # If a map column was appended, slice it off
-            external_map = data[:, -1]
-            data = data[:, :-1]
-            # Check for garbage
-            duplicates = len(external_map) - len(np.unique(external_map))
-            if duplicates:
-                raise SourceQualityError(f"{duplicates} duplicates in source '{src}'")
-            # And store it as appendix dataset
-            self.scaffold.append_dset(self.name + "_ext_map", external_map)
-        # Store the CSV positions in the scaffold
-        self.scaffold.place_cells(self.cell_type, None, data)

--- a/bsb/placement/strategy.py
+++ b/bsb/placement/strategy.py
@@ -6,17 +6,16 @@ from ..exceptions import (
     SourceQualityError,
 )
 from ..profiling import node_meter
-from ..reporting import report, warn
+from ..reporting import report
 from ..config import refs, types
 from .._util import SortableByAfter, obj_str_insert
 from ..voxels import VoxelSet
 from ..storage import Chunk
 from .indicator import PlacementIndications, PlacementIndicator
-from .distributor import DistributorsNode, Implicit
+from .distributor import DistributorsNode
 import numpy as np
 import itertools
 import abc
-import os
 
 
 @config.dynamic(attr_name="strategy", required=True)

--- a/bsb/plugins.py
+++ b/bsb/plugins.py
@@ -10,7 +10,7 @@ from .exceptions import PluginError
 import types
 
 
-def discover(category, *args, **kwargs):
+def discover(category):
     """
     Discover all plugins for a given category.
 

--- a/bsb/services/pool.py
+++ b/bsb/services/pool.py
@@ -169,12 +169,11 @@ class ConnectivityJob(ChunkedJob):
     Dispatches the execution of a chunk of a placement strategy through a JobPool.
     """
 
-    def __init__(self, pool, strategy, chunk, roi, deps=None):
-        args = (strategy.name, chunk, roi)
+    def __init__(self, pool, strategy, pre_roi, post_roi, deps=None):
+        args = (strategy.name, pre_roi, post_roi)
         Job.__init__(self, pool, strategy.connect.__func__, args, {}, deps=deps)
         self._cname = strategy.__class__.__name__
         self._name = strategy.name
-        self._c = chunk
 
     @staticmethod
     def execute(job_owner, f, args, kwargs):
@@ -237,8 +236,8 @@ class JobPool:
         self._put(job)
         return job
 
-    def queue_connectivity(self, strategy, chunk, roi, deps=None):
-        job = ConnectivityJob(self, strategy, chunk, roi, deps)
+    def queue_connectivity(self, strategy, pre_roi, post_roi, deps=None):
+        job = ConnectivityJob(self, strategy, pre_roi, post_roi, deps)
         self._put(job)
         return job
 

--- a/bsb/storage/__init__.py
+++ b/bsb/storage/__init__.py
@@ -17,6 +17,7 @@ from ..exceptions import UnknownStorageEngineError
 from .. import plugins
 from ..services import MPI
 from ._chunks import Chunk, chunklist
+from ._files import FileDependency, FileDependencyNode, NrrdDependencyNode
 
 
 # Pretend `Chunk` is defined here, for UX. It's only defined in `_chunks` to avoid

--- a/bsb/storage/__init__.py
+++ b/bsb/storage/__init__.py
@@ -40,7 +40,7 @@ def discover_engines():
     """
     Get a dictionary of all available storage engines.
     """
-    engines = plugins.discover("engines")
+    engines = plugins.discover("storage.engines")
     for engine_name, engine_module in engines.items():
         register_engine(engine_name, engine_module)
     return engines

--- a/bsb/storage/_chunks.py
+++ b/bsb/storage/_chunks.py
@@ -31,21 +31,24 @@ class Chunk(np.ndarray):
         return self.id != other.id
 
     def __eq__(self, other):
-        self_id = np.array(self, copy=False).view(Chunk)._safe_id()
-        other_id = np.array(other, copy=False).view(Chunk)._safe_id()
+        self_id, other_id = _safe_ids(self, other)
         return self_id == other_id
 
     def __gt__(self, other):
-        return self.id > other.id
+        self_id, other_id = _safe_ids(self, other)
+        return self_id > other_id
 
     def __lt__(self, other):
-        return self.id < other.id
+        self_id, other_id = _safe_ids(self, other)
+        return self_id < other_id
 
     def __ge__(self, other):
-        return self.id >= other.id
+        self_id, other_id = _safe_ids(self, other)
+        return self_id >= other_id
 
     def __le__(self, other):
-        return self.id <= other.id
+        self_id, other_id = _safe_ids(self, other)
+        return self_id <= other_id
 
     def __hash__(self):
         return int(self.id)
@@ -100,3 +103,10 @@ class Chunk(np.ndarray):
 
 def chunklist(chunks: typing.Iterable[Chunklike]) -> typing.List[Chunk]:
     return sorted(set(c if isinstance(c, Chunk) else Chunk(c, None) for c in chunks))
+
+
+def _safe_ids(self, other):
+    return (
+        np.array(self, copy=False).view(Chunk)._safe_id(),
+        np.array(other, copy=False).view(Chunk)._safe_id(),
+    )

--- a/bsb/storage/_files.py
+++ b/bsb/storage/_files.py
@@ -1,0 +1,164 @@
+import abc as _abc
+import contextlib as _cl
+import os
+import tempfile
+import urllib.parse as _up
+import urllib.request as _ur
+import pathlib as _pl
+import os as _os
+import functools as _ft
+import typing as _t
+
+from .._util import obj_str_insert
+
+if _t.TYPE_CHECKING:
+    from ..core import Scaffold
+
+
+def _is_uri(url):
+    return _up.urlparse(url).scheme != ""
+
+
+def _uri_to_path(uri):
+    parsed = _up.urlparse(uri)
+    host = "{0}{0}{mnt}{0}".format(_os.path.sep, mnt=parsed.netloc)
+    return _os.path.relpath(
+        _os.path.normpath(_os.path.join(host, _ur.url2pathname(_up.unquote(parsed.path))))
+    )
+
+
+class FileDependency:
+    def __init__(self, source: str, ext: str = None):
+        self._given_source: str = source
+        if _is_uri(source):
+            self._uri = source
+        else:
+            self._uri: str = _pl.Path(source).absolute().as_uri()
+        self._scheme: "FileScheme" = _get_scheme(_up.urlparse(self._uri).scheme)
+        self.file_store: "FileStore" = None
+        self.extension = ext
+
+    @obj_str_insert
+    def __str__(self):
+        return f"'{self._uri}'"
+
+    def get_content(self, check_store=True):
+        if check_store:
+            stored = self.get_stored_file()
+            if stored is None or self._scheme.should_update(self, stored):
+                content = self._get_content()
+                self.store_content(content)
+                return content
+            else:
+                return stored.load()
+        else:
+            return self._get_content()
+
+    @_cl.contextmanager
+    def provide_locally(self):
+        try:
+            with self._scheme.provide_locally(self) as path:
+                yield path
+        except FileNotFoundError:
+            if self.file_store is None:
+                print("err out")
+                raise
+            content = self.get_content()
+            with tempfile.TemporaryDirectory() as dirpath:
+                name = "file"
+                if self.extension:
+                    name = f"{name}.{self.extension}"
+                filepath = _os.path.join(dirpath, name)
+                with open(filepath, "wb") as f:
+                    f.write(content)
+                yield dirpath
+
+    def get_stored_file(self):
+        if not self.file_store:
+            raise ValueError(
+                "Can't check for file dependency in store before scaffold is ready."
+            )
+        return self.file_store.find_meta("source", self._given_source)
+
+    def store_content(self, content):
+        if not self.file_store:
+            raise ValueError(
+                "Can't store file dependency in store before scaffold is ready."
+            )
+        return self.file_store.store(content, meta={"source": self._given_source})
+
+    def should_update(self):
+        if not self.file_store:
+            raise ValueError(
+                "Can't update file dependency in store before scaffold is ready."
+            )
+        stored = self.get_stored_file()
+        return stored is None or self._scheme.should_update(self, stored)
+
+    def _get_content(self):
+        if not self._scheme.find(self):
+            raise FileNotFoundError(f"Couldn't find {self._uri}")
+        return self._scheme.get_content(self)
+
+    def update(self, force=False):
+        if force or self.should_update():
+            self.get_content()
+
+
+class UriScheme(_abc.ABC):
+    @_abc.abstractmethod
+    def find(self, file: FileDependency):
+        path = _uri_to_path(file._uri)
+        return _os.path.exists(path)
+
+    @_abc.abstractmethod
+    def should_update(self, file: FileDependency, stored_file):
+        path = _uri_to_path(file._uri)
+        return _os.path.getmtime(path) > stored_file.mtime
+
+    @_abc.abstractmethod
+    def get_content(self, file: FileDependency):
+        path = _uri_to_path(file._uri)
+        with open(path, "rb") as f:
+            return f.read()
+
+    @_abc.abstractmethod
+    @_cl.contextmanager
+    def provide_locally(self, file: FileDependency):
+        if not self.find(file):
+            raise FileNotFoundError(f"Can't find {file}.")
+        yield _uri_to_path(file._uri)
+
+    def get_local_path(self, file: FileDependency):
+        return _uri_to_path(file._uri)
+
+
+class FileScheme(UriScheme):
+    def find(self, file: FileDependency):
+        return super().find(file)
+
+    def should_update(self, file: FileDependency, stored_file):
+        return super().should_update(file, stored_file)
+
+    def get_content(self, file: FileDependency):
+        return super().get_content(file)
+
+    def provide_locally(self, file: FileDependency):
+        return super().provide_locally(file)
+
+
+@_ft.cache
+def _get_schemes() -> _t.Mapping[str, FileScheme]:
+    from ..plugins import discover
+
+    schemes = discover("storage.schemes")
+    schemes["file"] = FileScheme()
+    return schemes
+
+
+def _get_scheme(scheme: str) -> FileScheme:
+    schemes = _get_schemes()
+    try:
+        return schemes[scheme]
+    except AttributeError:
+        raise AttributeError(f"{scheme} is not a known file scheme.")

--- a/bsb/storage/_files.py
+++ b/bsb/storage/_files.py
@@ -1,18 +1,30 @@
 import abc as _abc
 import contextlib as _cl
+import datetime
+import functools
+import json
 import os
 import tempfile
+import time
 import urllib.parse as _up
 import urllib.request as _ur
 import pathlib as _pl
 import os as _os
 import functools as _ft
 import typing as _t
+import requests
+import email.utils
+
+import nrrd
 
 from .._util import obj_str_insert
+from .. import config
+from ..config import types
 
 if _t.TYPE_CHECKING:
     from ..core import Scaffold
+    from ..storage.interfaces import FileStore
+    from ..morphologies import Morphology
 
 
 def _is_uri(url):
@@ -28,15 +40,26 @@ def _uri_to_path(uri):
 
 
 class FileDependency:
-    def __init__(self, source: str, ext: str = None):
+    def __init__(
+        self,
+        source: str,
+        file_store: "FileStore" = None,
+        ext: str = None,
+        cache=True,
+    ):
         self._given_source: str = source
         if _is_uri(source):
             self._uri = source
         else:
             self._uri: str = _pl.Path(source).absolute().as_uri()
         self._scheme: "FileScheme" = _get_scheme(_up.urlparse(self._uri).scheme)
-        self.file_store: "FileStore" = None
+        self.file_store = file_store
         self.extension = ext
+        self.cache = cache
+
+    @property
+    def uri(self):
+        return self._uri
 
     @obj_str_insert
     def __str__(self):
@@ -47,22 +70,33 @@ class FileDependency:
             stored = self.get_stored_file()
             if stored is None or self._scheme.should_update(self, stored):
                 content = self._get_content()
-                self.store_content(content)
+                if self.cache:
+                    self.store_content(content, meta=self._scheme.get_meta(self))
                 return content
             else:
                 return stored.load()
         else:
             return self._get_content()
 
+    def get_meta(self, check_store=True):
+        if (
+            not check_store or ((stored := self.get_stored_file()) is None)
+        ) or self._scheme.should_update(self, stored):
+            return self._scheme.get_meta(self)
+        else:
+            return stored.meta
+
     @_cl.contextmanager
     def provide_locally(self):
         try:
-            with self._scheme.provide_locally(self) as path:
-                yield path
-        except FileNotFoundError:
+            path = self._scheme.get_local_path(self)
+            if os.path.exists(path):
+                yield (path, None)
+            else:
+                raise FileNotFoundError()
+        except (TypeError, FileNotFoundError):
             if self.file_store is None:
-                print("err out")
-                raise
+                raise FileNotFoundError(f"Can't find {self}")
             content = self.get_content()
             with tempfile.TemporaryDirectory() as dirpath:
                 name = "file"
@@ -70,8 +104,8 @@ class FileDependency:
                     name = f"{name}.{self.extension}"
                 filepath = _os.path.join(dirpath, name)
                 with open(filepath, "wb") as f:
-                    f.write(content)
-                yield dirpath
+                    f.write(content[0])
+                yield (filepath, content[1])
 
     def get_stored_file(self):
         if not self.file_store:
@@ -80,12 +114,20 @@ class FileDependency:
             )
         return self.file_store.find_meta("source", self._given_source)
 
-    def store_content(self, content):
+    def store_content(self, content, encoding=None, meta=None):
         if not self.file_store:
             raise ValueError(
                 "Can't store file dependency in store before scaffold is ready."
             )
-        return self.file_store.store(content, meta={"source": self._given_source})
+        if isinstance(content, tuple):
+            content, encoding = content
+        # Save the file under the same id if it already exists
+        id_ = getattr(self.get_stored_file(), "id", None)
+        if meta is None:
+            meta = {}
+        meta.update(self._scheme.get_meta(self))
+        meta["source"] = self._given_source
+        return self.file_store.store(content, meta=meta, encoding=encoding, id=id_)
 
     def should_update(self):
         if not self.file_store:
@@ -108,29 +150,27 @@ class FileDependency:
 class UriScheme(_abc.ABC):
     @_abc.abstractmethod
     def find(self, file: FileDependency):
-        path = _uri_to_path(file._uri)
+        path = _uri_to_path(file.uri)
         return _os.path.exists(path)
 
     @_abc.abstractmethod
     def should_update(self, file: FileDependency, stored_file):
-        path = _uri_to_path(file._uri)
+        path = _uri_to_path(file.uri)
         return _os.path.getmtime(path) > stored_file.mtime
 
     @_abc.abstractmethod
     def get_content(self, file: FileDependency):
-        path = _uri_to_path(file._uri)
+        path = _uri_to_path(file.uri)
         with open(path, "rb") as f:
-            return f.read()
+            return (f.read(), None)
 
     @_abc.abstractmethod
-    @_cl.contextmanager
-    def provide_locally(self, file: FileDependency):
-        if not self.find(file):
-            raise FileNotFoundError(f"Can't find {file}.")
-        yield _uri_to_path(file._uri)
+    def get_meta(self, file: FileDependency):
+        return {}
 
+    @_abc.abstractmethod
     def get_local_path(self, file: FileDependency):
-        return _uri_to_path(file._uri)
+        raise RuntimeError(f"{type(self)} has no local path representation")
 
 
 class FileScheme(UriScheme):
@@ -143,8 +183,45 @@ class FileScheme(UriScheme):
     def get_content(self, file: FileDependency):
         return super().get_content(file)
 
-    def provide_locally(self, file: FileDependency):
-        return super().provide_locally(file)
+    def get_meta(self, file: FileDependency):
+        return super().get_meta(file)
+
+    def get_local_path(self, file: FileDependency):
+        return _uri_to_path(file.uri)
+
+
+class UrlScheme(UriScheme):
+    def find(self, file: FileDependency):
+        response = requests.head(file.uri)
+        return response.status_code == 200
+
+    def should_update(self, file: FileDependency, stored_file):
+        mtime = stored_file.mtime
+        headers = self.get_meta(file).get("headers", {})
+        stored_headers = stored_file.meta.get("headers", {})
+        if "ETag" in headers:
+            new_etag = headers["ETag"]
+            old_etag = stored_headers.get("ETag")
+            # Check if we have the latest ETag
+            return old_etag != new_etag
+        elif "Last-Modified" in headers:
+            their_mtime = datetime.datetime(
+                *email.utils.parsedate(headers["Last-Modified"])[:6]
+            ).timestamp()
+            return their_mtime > mtime
+        # 100h default expiration
+        return time.time() > mtime + 360000
+
+    def get_content(self, file: FileDependency):
+        response = requests.get(file.uri)
+        return (response.content, response.encoding)
+
+    def get_meta(self, file: FileDependency):
+        response = requests.head(file.uri)
+        return {"headers": dict(response.headers)}
+
+    def get_local_path(self, file: FileDependency):
+        raise TypeError("URL schemes don't have a local path")
 
 
 @_ft.cache
@@ -153,6 +230,7 @@ def _get_schemes() -> _t.Mapping[str, FileScheme]:
 
     schemes = discover("storage.schemes")
     schemes["file"] = FileScheme()
+    schemes["http"] = schemes["https"] = UrlScheme()
     return schemes
 
 
@@ -162,3 +240,102 @@ def _get_scheme(scheme: str) -> FileScheme:
         return schemes[scheme]
     except AttributeError:
         raise AttributeError(f"{scheme} is not a known file scheme.")
+
+
+@config.node
+class FileDependencyNode:
+    file: "FileDependency" = config.file()
+
+    def __init__(self, value=None, **kwargs):
+        if value is not None:
+            self.file = value
+
+    def __inv__(self):
+        if not isinstance(self, FileDependencyNode):
+            return self
+        if self._config_pos_init:
+            return self.file._given_source
+        else:
+            return self.__tree__()
+
+    def load_object(self):
+        return self.file.get_content()
+
+
+@config.node
+class CodeDependencyNode(FileDependencyNode):
+    module: str = config.attr(type=str)
+
+    @config.property
+    def file(self):
+        if getattr(self, "scaffold", None) is not None:
+            file_store = self.scaffold.files
+        else:
+            file_store = None
+        return FileDependency(
+            self.module.replace(".", os.sep) + ".py", file_store=file_store
+        )
+
+    def __init__(self, module=None, **kwargs):
+        super().__init__(**kwargs)
+        if module is not None:
+            self.module = module
+
+    def load_object(self):
+        import importlib.util
+        import sys
+
+        sys.path.append(os.getcwd())
+        try:
+            with self.file.provide_locally() as (path, encoding):
+                spec = importlib.util.spec_from_file_location(self.module, path)
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[self.module] = module
+                spec.loader.exec_module(module)
+        finally:
+            tmp = list(reversed(sys.path))
+            tmp.remove(os.getcwd())
+            sys.path = list(reversed(tmp))
+
+
+@config.node
+class Operation:
+    func = config.attr(type=types.function_())
+    parameters = config.catch_all()
+
+    def __init__(self, value=None, /, **kwargs):
+        if value is not None:
+            self.func = value
+
+    def process(self, obj):
+        return self.func(obj, self.parameters)
+
+
+class FilePipelineMixin:
+    pipeline = config.list(type=Operation)
+
+    def pipe(self, input):
+        return functools.reduce(lambda state, func: func(state), self.pipeline, input)
+
+
+@config.node
+class NrrdDependencyNode(FilePipelineMixin, FileDependencyNode):
+    def get_header(self):
+        with self.file.provide_locally() as (path, encoding):
+            return nrrd.read_header(path)
+
+    def get_data(self):
+        with self.file.provide_locally() as (path, encoding):
+            return nrrd.read(path)[0]
+
+    def load_object(self):
+        return self.pipe(self.get_data())
+
+
+@config.node
+class MorphologyDependencyNode(FilePipelineMixin, FileDependencyNode):
+    def load_object(self) -> "Morphology":
+        from ..morphologies import Morphology
+
+        with self.file.provide_locally() as (path, encoding):
+            return self.pipe(Morphology.from_file(path))

--- a/bsb/storage/_files.py
+++ b/bsb/storage/_files.py
@@ -125,7 +125,9 @@ class FileDependency:
             meta = {}
         meta.update(self._scheme.get_meta(self))
         meta["source"] = self._given_source
-        return self.file_store.store(content, meta=meta, encoding=encoding, id=id_)
+        return self.file_store.store(
+            content, meta=meta, encoding=encoding, id=id_, overwrite=True
+        )
 
     def should_update(self):
         if not self.file_store:

--- a/bsb/storage/_files.py
+++ b/bsb/storage/_files.py
@@ -259,11 +259,15 @@ def _get_scheme(scheme: str) -> FileScheme:
 
 @config.node
 class FileDependencyNode:
-    file: "FileDependency" = config.file()
+    file: "FileDependency" = config.attr(type=FileDependency)
 
     def __init__(self, value=None, **kwargs):
         if value is not None:
             self.file = value
+
+    def __boot__(self):
+        self.file.file_store = self.scaffold.files
+        self.file.update()
 
     def __inv__(self):
         if not isinstance(self, FileDependencyNode):

--- a/bsb/storage/_util.py
+++ b/bsb/storage/_util.py
@@ -1,121 +1,33 @@
-import os
-import io
+import functools
 import pathlib
+import typing
+
 import appdirs
-import contextlib
+
+from ._files import FileDependency
+
+if typing.TYPE_CHECKING:
+    from .interfaces import Storage
 
 _bsb_dirs = appdirs.AppDirs("bsb")
 _cache_path = pathlib.Path(_bsb_dirs.user_cache_dir)
 
-
-class _NoLink:
-    def exists(self):
-        return False
-
-    def get(self):
-        return io.StringIO("")
+cache: "Storage"
 
 
-class FileLink:
-    _type = "sys"
-
-    def __init__(self, path, update="always", binary=False):
-        self.path = pathlib.Path(path).resolve()
-        self.upd_mode = update
-        self.binary = binary
-
-    @property
-    def type(self):
-        return self._type
-
-    def __str__(self):
-        return f"<filesystem link '{self.path}'>"
-
-    def exists(self):
-        return self.path.exists()
-
-    def should_update(self, last_retrieved=None):
-        if not self.exists():
-            return False
-        if self.upd_mode == "never":
-            return False
-        if last_retrieved is None:
-            return True
-        else:
-            return os.path.getmtime(self.path) > last_retrieved
-
-    def get(self, binary=None):
-        binary = self.binary if binary is None else binary
-        return open(self.path, f"r{'b' if binary else ''}")
-
-    def set(self, binary=None):
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        binary = self.binary if binary is None else binary
-        return open(self.path, f"w{'b' if binary else ''}")
-
-
-class CacheLink(FileLink):
-    _type = "cache"
-
-    def __init__(self, path, update="never", binary=False):
-        path = _cache_path / path
-        super().__init__(path, update=update, binary=binary)
-
-    def should_update(self, source_timestamp=None):
-        if not self.exists():
-            return True
-        if self.upd_mode == "never":
-            return False
-        return os.path.getmtime(self.path) < source_timestamp
-
-
-class StoreLink(FileLink):
-    _type = "store"
-
-    def __init__(self, store, id, update="always", binary=False):
-        self.store = store
-        self.id = id
-        self.upd_mode = update
-        self.binary = binary
-
-    def __str__(self):
-        return f"<filestore link '{self.id}@{self.store}'>"
-
-    def exists(self):
-        return self.id in self.store.all()
-
-    def should_update(self):
-        return False
-
-    def get(self, binary=None):
-        binary = self.binary if binary is None else binary
-        return self.store.stream(self.id, binary=binary)
-
-
-def syslink(path, update="always", binary=False):
-    return FileLink(pathlib.Path(os.path.abspath(path)), update=update, binary=binary)
-
-
-def cachelink(path, update="never", binary=False):
-    return CacheLink(path, update=update, binary=binary)
-
-
-def storelink(store, id, update="always", binary=False):
-    return StoreLink(store, id, update=update, binary=binary)
-
-
-def link(store, proj_dir, source, id, update):
-    if source == "sys":
-        return FileLink(proj_dir / id, update=update)
-    elif source == "store":
-        return StoreLink(store, id, update=update)
-    elif source == "cache":
-        return CacheLink(id, update=update)
+def __getattr__(name):
+    if name == "cache":
+        return _get_cache_storage()
     else:
-        raise ValueError(
-            f"'{source}' not a valid link source. Pick 'sys', 'store' or 'cache'."
-        )
+        raise AttributeError(f"{__name__} has no attribute '{name}.")
 
 
-def nolink():
-    return _NoLink()
+@functools.cache
+def _get_cache_storage():
+    from bsb.storage import Storage
+
+    return Storage("fs", _cache_path)
+
+
+def _cached_file(source, cache=True):
+    return FileDependency(source, file_store=_get_cache_storage().files, cache=cache)

--- a/bsb/storage/fs/__init__.py
+++ b/bsb/storage/fs/__init__.py
@@ -1,0 +1,95 @@
+import shutil
+from datetime import datetime
+
+import shortuuid
+
+from ... import config
+from ...services import MPILock
+from ..interfaces import Engine, NoopLock, StorageNode as IStorageNode
+from .file_store import FileStore
+import os
+
+
+class FileSystemEngine(Engine):
+    def __init__(self, root, comm):
+        super().__init__(root, comm)
+        self._lock = MPILock.sync()
+        self._readonly = False
+
+    @property
+    def root_slug(self):
+        return os.path.relpath(self._root)
+
+    @classmethod
+    def recognizes(cls, root):
+        try:
+            return os.path.exists(root) and os.path.isdir(root)
+        except Exception:
+            return False
+
+    def _read(self):
+        if self._readonly:
+            return NoopLock()
+        else:
+            return self._lock.read()
+
+    def _write(self):
+        if self._readonly:
+            raise IOError("Can't perform write operations in readonly mode.")
+        else:
+            return self._lock.write()
+
+    def _master_write(self):
+        if self._readonly:
+            raise IOError("Can't perform write operations in readonly mode.")
+        else:
+            return self._lock.single_write()
+
+    def exists(self):
+        return os.path.exists(self._root)
+
+    def create(self):
+        os.makedirs(os.path.join(self._root, "files"), exist_ok=True)
+        os.makedirs(os.path.join(self._root, "file_meta"), exist_ok=True)
+
+    def move(self, new_root):
+        shutil.move(self._root, new_root)
+        self._root = new_root
+
+    def copy(self, new_root):
+        shutil.copytree(self._root, new_root)
+
+    def remove(self):
+        os.remove(self._root)
+
+    def require_placement_set(self, ct):
+        raise NotImplementedError("No PS")
+
+    def clear_placement(self):
+        pass
+
+    def clear_connectivity(self):
+        pass
+
+    def get_chunk_stats(self):
+        return {}
+
+
+def _get_default_root():
+    return os.path.abspath(
+        os.path.join(
+            ".",
+            "scaffold_network_"
+            + datetime.now().strftime("%Y_%m_%d")
+            + "_"
+            + shortuuid.uuid(),
+        )
+    )
+
+
+@config.node
+class StorageNode(IStorageNode):
+    root = config.attr(type=str, default=_get_default_root, call_default=True)
+    """
+    Path to the filesystem storage file.
+    """

--- a/bsb/storage/fs/file_store.py
+++ b/bsb/storage/fs/file_store.py
@@ -1,0 +1,146 @@
+import json
+import os
+import time
+import typing
+from uuid import uuid4
+import base64
+
+from ..interfaces import FileStore as IFileStore
+
+
+def _id_to_path(url):
+    return base64.urlsafe_b64encode(url.encode("UTF-8")).decode("UTF-8")
+
+
+def _path_to_id(f):
+    return base64.urlsafe_b64decode(f).decode("UTF-8")
+
+
+class FileStore(IFileStore):
+    def file_path(self, *paths):
+        return os.path.join(self._engine.root, "files", *paths)
+
+    def id_to_file_path(self, id):
+        path = _id_to_path(id)
+        return self.file_path(path)
+
+    def meta_path(self, *paths):
+        return os.path.join(self._engine.root, "file_meta", *paths)
+
+    def id_to_meta_path(self, id):
+        path = _id_to_path(id)
+        return self.meta_path(path)
+
+    def all(self):
+        return {
+            id: self.get_meta(id) for id in map(_path_to_id, os.listdir(self.file_path()))
+        }
+
+    def store(self, content, id=None, meta=None, encoding=None):
+        if isinstance(content, str):
+            if encoding is None:
+                encoding = "utf-8"
+            content = content.encode(encoding)
+        if id is None:
+            id = str(uuid4())
+        if meta is None:
+            meta = {}
+        with open(self.id_to_file_path(id), "wb") as f:
+            f.write(content)
+        with open(self.id_to_meta_path(id), "w") as f:
+            json.dump({"meta": meta, "mtime": time.time(), "encoding": encoding}, f)
+        return id
+
+    def load(self, id):
+        """
+        Load the content of an object in the file store.
+
+        :param id: id of the content to be loaded.
+        :type id: str
+        :returns: The content of the stored object
+        :rtype: str
+        :raises FileNotFoundError: The given id doesn't exist in the file store.
+        """
+        with open(self.id_to_file_path(id), "rb") as f:
+            content = f.read()
+        our_meta = self._get_meta(id)
+        meta = our_meta["meta"]
+        encoding = our_meta["encoding"]
+        return (content.decode(encoding) if encoding else content), meta
+
+    def remove(self, id):
+        """
+        Remove the content of an object in the file store.
+
+        :param id: id of the content to be removed.
+        :type id: str
+        :raises FileNotFoundError: The given id doesn't exist in the file store.
+        """
+        os.unlink(self.id_to_file_path(id))
+        os.unlink(self.id_to_meta_path(id))
+
+    def store_active_config(self, config):
+        """
+        Store configuration in the file store and mark it as the active configuration of
+        the stored network.
+
+        :param config: Configuration to be stored
+        :type config: :class:`~.config.Configuration`
+        :returns: The id the config was stored under
+        :rtype: str
+        """
+        return self.store(json.dumps(config.__tree__()), meta={"active_config": True})
+
+    def load_active_config(self):
+        """
+        Load the active configuration stored in the file store.
+
+        :returns: The active configuration
+        :rtype: :class:`~.config.Configuration`
+        :raises Exception: When there's no active configuration in the file store.
+        """
+        from bsb.config import Configuration
+        from bsb.config._config import _bootstrap_components
+
+        stored = self.find_meta("active_config", True)
+        if stored is None:
+            raise Exception("No active config")
+        else:
+            content, meta = stored.load()
+            tree = json.loads(content)
+            _bootstrap_components(tree.get("components", []), self)
+            cfg = Configuration(**tree)
+            cfg._meta = meta
+            return cfg
+
+    def has(self, id):
+        """
+        Must return whether the file store has a file with the given id.
+        """
+        return os.path.exists(self.id_to_file_path(id))
+
+    def get_mtime(self, id):
+        """
+        Must return the last modified timestamp of file with the given id.
+        """
+        return self._get_meta(id)["mtime"]
+
+    def get_encoding(self, id):
+        """
+        Must return the encoding of the file with the given id, or None if it is
+        unspecified binary data.
+        """
+        return self._get_meta(id)["encoding"]
+
+    def _get_meta(self, id) -> typing.Mapping[str, typing.Any]:
+        """
+        Must return the metadata of the given id.
+        """
+        with open(self.id_to_meta_path(id), "r") as f:
+            return json.load(f)
+
+    def get_meta(self, id) -> typing.Mapping[str, typing.Any]:
+        """
+        Must return the metadata of the given id.
+        """
+        return self._get_meta(id)["meta"]

--- a/bsb/storage/fs/file_store.py
+++ b/bsb/storage/fs/file_store.py
@@ -36,7 +36,7 @@ class FileStore(IFileStore):
             id: self.get_meta(id) for id in map(_path_to_id, os.listdir(self.file_path()))
         }
 
-    def store(self, content, id=None, meta=None, encoding=None):
+    def store(self, content, id=None, meta=None, encoding=None, overwrite=False):
         if isinstance(content, str):
             if encoding is None:
                 encoding = "utf-8"
@@ -45,6 +45,8 @@ class FileStore(IFileStore):
             id = str(uuid4())
         if meta is None:
             meta = {}
+        if not overwrite and self.has(id):
+            raise FileExistsError(f"Store already contains a file with id {id}")
         with open(self.id_to_file_path(id), "wb") as f:
             f.write(content)
         with open(self.id_to_meta_path(id), "w") as f:

--- a/bsb/storage/interfaces.py
+++ b/bsb/storage/interfaces.py
@@ -230,7 +230,7 @@ class FileStore(Interface, engine_key="files"):
         :param encoding: Optional encoding
         :type encoding: str
         :param overwrite: Overwrite existing file
-        :type overwrite: boolean
+        :type overwrite: bool
         :returns: The id the content was stored under
         :rtype: str
         """

--- a/bsb/storage/interfaces.py
+++ b/bsb/storage/interfaces.py
@@ -216,7 +216,7 @@ class FileStore(Interface, engine_key="files"):
         pass
 
     @abc.abstractmethod
-    def store(self, content, id=None, meta=None, encoding=None):
+    def store(self, content, id=None, meta=None, encoding=None, overwrite=False):
         """
         Store content in the file store. Should also store the current timestamp as
         `mtime` meta.
@@ -227,6 +227,10 @@ class FileStore(Interface, engine_key="files"):
         :type id: str
         :param meta: Metadata for the content
         :type meta: dict
+        :param encoding: Optional encoding
+        :type encoding: str
+        :param overwrite: Overwrite existing file
+        :type overwrite: boolean
         :returns: The id the content was stored under
         :rtype: str
         """
@@ -464,6 +468,10 @@ class PlacementSet(Interface):
         pass
 
     @abc.abstractmethod
+    def load_ids(self):
+        pass
+
+    @abc.abstractmethod
     def load_positions(self):
         """
         Return a dataset of cell positions.
@@ -493,6 +501,10 @@ class PlacementSet(Interface):
         :returns: Set of morphologies
         :rtype: :class:`~.morphologies.MorphologySet`
         """
+        pass
+
+    @abc.abstractmethod
+    def load_additional(self, key=None):
         pass
 
     def count_morphologies(self):
@@ -553,6 +565,10 @@ class PlacementSet(Interface):
         :param data: Arbitrary user data. You decide |:heart:|
         :type data: numpy.ndarray
         """
+        pass
+
+    @abc.abstractmethod
+    def chunk_context(self, chunks):
         pass
 
     @abc.abstractmethod

--- a/bsb/topology/partition.py
+++ b/bsb/topology/partition.py
@@ -33,7 +33,6 @@ class _backref_property(property):
 
 @config.dynamic(
     attr_name="type",
-    type=types.in_classmap(),
     required=False,
     default="layer",
     auto_classmap=True,

--- a/bsb/topology/partition.py
+++ b/bsb/topology/partition.py
@@ -281,7 +281,7 @@ class Layer(Rhomboid, classmap_entry="layer"):
 
 
 @config.node
-class Voxels(Partition, abc.ABC, classmap_entry="voxels"):
+class Voxels(Partition, abc.ABC, classmap_entry=None):
     @abc.abstractmethod
     def get_voxelset(self):
         pass

--- a/bsb/topology/partition.py
+++ b/bsb/topology/partition.py
@@ -5,11 +5,18 @@
 from ._layout import Layout, RhomboidData
 from .. import config
 from ..config import types
-from ..config.refs import region_ref
-from ..exceptions import *
+from ..exceptions import (
+    RequirementError,
+    LayoutError,
+    ConfigurationError,
+    AllenApiError,
+    NodeNotFoundError,
+)
+from ..storage._files import NrrdDependencyNode
+from ..storage._util import _cached_file
 from ..voxels import VoxelSet
-from ..storage import Chunk, _util as _storutil
-from ..reporting import report, warn
+from ..storage import Chunk
+from ..reporting import report
 import numpy as np
 import collections
 import functools
@@ -324,13 +331,15 @@ class Voxels(Partition, abc.ABC, classmap_entry="voxels"):
 @config.node
 class NrrdVoxels(Voxels, classmap_entry="nrrd"):
     source = config.attr(
-        type=str, required=types.mut_excl("source", "sources", required=True)
+        type=NrrdDependencyNode,
+        required=types.mut_excl("source", "sources", required=True),
     )
     sources = config.attr(
-        type=types.list(str), required=types.mut_excl("source", "sources", required=True)
+        type=types.list(NrrdDependencyNode),
+        required=types.mut_excl("source", "sources", required=True),
     )
     mask_value = config.attr(type=int)
-    mask_source = config.attr(type=str)
+    mask_source = config.attr(type=NrrdDependencyNode)
     mask_only = config.attr(type=bool, default=False)
     voxel_size = config.attr(type=types.voxel_size(), required=True)
     keys = config.attr(type=types.list(str))
@@ -344,7 +353,7 @@ class NrrdVoxels(Voxels, classmap_entry="nrrd"):
             # Use integer (sparse) indexing
             mask = [np.empty((0,), dtype=int) for i in range(3)]
             for mask_src in self._mask_src:
-                mask_data, _ = nrrd.read(mask_src)
+                mask_data = mask_src.get_data()
                 new_mask = np.nonzero(self._mask_cond(mask_data))
                 for i, mask_vector in enumerate(new_mask):
                     mask[i] = np.concatenate((mask[i], mask_vector))
@@ -353,23 +362,23 @@ class NrrdVoxels(Voxels, classmap_entry="nrrd"):
         else:
             # Use boolean (dense) indexing
             for mask_src in self._mask_src:
-                mask_data, _ = nrrd.read(mask_src)
+                mask_data = mask_src.get_data()
                 mask = mask | self._mask_cond(mask_data)
             mask = np.nonzero(mask)
         return mask
 
     def get_voxelset(self):
         mask = self.get_mask()
+        voxel_data = None
         if not self.mask_only:
             voxel_data = np.empty((len(mask[0]), len(self._src)))
             for i, source in enumerate(self._src):
-                data, _ = nrrd.read(source)
-                voxel_data[:, i] = data[mask]
+                voxel_data[:, i] = source.get_data()[mask]
 
         return VoxelSet(
             np.transpose(mask),
             self.voxel_size,
-            data=voxel_data if not self.mask_only else None,
+            data=voxel_data,
             data_keys=self.keys,
         )
 
@@ -390,8 +399,8 @@ class NrrdVoxels(Voxels, classmap_entry="nrrd"):
             self._mask_src = self._src.copy()
 
     def _validate_source_compat(self):
-        mask_headers = {s: _safe_hread(s) for s in self._mask_src}
-        source_headers = {s: _safe_hread(s) for s in self._src}
+        mask_headers = {s: s.get_header() for s in self._mask_src}
+        source_headers = {s: s.get_header() for s in self._src}
         all_headers = mask_headers.copy()
         all_headers.update(source_headers)
         dim_probs = [(s, d) for s, h in all_headers.items() if (d := h["dimension"]) != 3]
@@ -437,10 +446,11 @@ class AllenStructure(NrrdVoxels, classmap_entry="allen"):
         required=types.mut_excl("struct_id", "struct_name", required=True),
     )
     source = config.attr(
-        type=str, required=types.mut_excl("source", "sources", required=False)
+        type=NrrdDependencyNode,
+        required=types.mut_excl("source", "sources", required=False),
     )
     sources = config.attr(
-        type=types.list(str),
+        type=types.list(NrrdDependencyNode),
         required=types.mut_excl("source", "sources", required=False),
         default=list,
         call_default=True,
@@ -457,39 +467,20 @@ class AllenStructure(NrrdVoxels, classmap_entry="allen"):
     @config.property
     @functools.cache
     def mask_source(self):
-        return self._dl_mask()
-
-    @classmethod
-    def _dl_mask(cls):
-        url = "http://download.alleninstitute.org/informatics-archive/current-release/mouse_ccf/annotation/ccf_2017/annotation_25.nrrd"
-        fname = "_annotations_25.nrrd.cache"
-        link = _storutil.cachelink(fname, binary=True)
-        if link.should_update():
-            with link.set() as f:
-                report("Downloading Allen Brain Atlas annotations", level=3)
-                content = requests.get(url).content
-                f.write(requests.get(url).content)
-        else:
-            report("Using cached Allen Brain Atlas annotations", level=4)
-        return str(link.path)
+        node = NrrdDependencyNode()
+        node._file = _cached_file(
+            "http://download.alleninstitute.org/informatics-archive/current-release/mouse_ccf/annotation/ccf_2017/annotation_25.nrrd",
+        )
+        return node
 
     @classmethod
     @functools.cache
     def _dl_structure_ontology(cls):
-        url = "http://api.brain-map.org/api/v2/structure_graph_download/1.json"
-        fname = "_allen_ontology.cache"
-        link = _storutil.cachelink(fname)
-        if link.should_update():
-            report("Downloading Allen Brain Atlas structure ontology", level=3)
-            payload = requests.get(url).json()
-            if not payload.get("success", False):
-                raise AllenApiError(f"Could not fetch ontology from Allen API at '{url}'")
-            with link.set() as f:
-                json.dump(payload["msg"], f)
-        else:
-            report("Using cached Allen Brain Atlas ontology", level=4)
-        with link.get() as f:
-            return json.load(f)
+        return json.loads(
+            _cached_file(
+                "http://api.brain-map.org/api/v2/structure_graph_download/1.json"
+            ).get_content()[0]
+        )["msg"]
 
     @classmethod
     def get_structure_mask_condition(cls, find):

--- a/bsb/voxels.py
+++ b/bsb/voxels.py
@@ -493,10 +493,15 @@ class VoxelSet:
     def fill(cls, positions, voxel_size, unique=True):
         return cls(positions, 0, irregular=True).snap_to_grid(voxel_size, unique=unique)
 
-    def index_of(self, positions):
+    def coordinates_of(self, positions):
         if not self.regular:
             raise ValueError("Cannot find a unique voxel index in irregular VoxelSet.")
         return positions // self.get_size()
+
+    def index_of(self, positions):
+        coords = self.coordinates_of(positions)
+        map_ = {tuple(vox_coord): i for i, vox_coord in enumerate(self)}
+        return np.array([map_.get(tuple(coord), np.nan) for coord in coords])
 
     def inside(self, positions):
         mask = np.zeros(len(positions), dtype=bool)

--- a/bsb/voxels.py
+++ b/bsb/voxels.py
@@ -454,11 +454,11 @@ class VoxelSet:
         else:
             return self._boxtree()
 
-    def snap_to_grid(self, grid_size, unique=False):
+    def snap_to_grid(self, voxel_size, unique=False):
         if self.regular:
-            grid = self._indices // _squash_zero(grid_size / _squash_zero(self._size))
+            grid = self._indices // _squash_zero(voxel_size / _squash_zero(self._size))
         else:
-            grid = self._coords // _squash_zero(grid_size)
+            grid = self._coords // _squash_zero(voxel_size)
         data = self._data
         if unique:
             if self.has_data:
@@ -466,7 +466,7 @@ class VoxelSet:
                 data = data[id]
             else:
                 grid = np.unique(grid, axis=0)
-        return VoxelSet(grid, grid_size, data)
+        return VoxelSet(grid, voxel_size, data)
 
     def resize(self, size):
         val = np.array(size, copy=False)
@@ -490,8 +490,13 @@ class VoxelSet:
         return self.crop(chunk.ldc, chunk.mdc)
 
     @classmethod
-    def fill(cls, positions, grid_size):
-        return cls(positions, 0, irregular=True).snap_to_grid(grid_size, unique=True)
+    def fill(cls, positions, voxel_size, unique=True):
+        return cls(positions, 0, irregular=True).snap_to_grid(voxel_size, unique=unique)
+
+    def index_of(self, positions):
+        if not self.regular:
+            raise ValueError("Cannot find a unique voxel index in irregular VoxelSet.")
+        return positions // self.get_size()
 
     def inside(self, positions):
         mask = np.zeros(len(positions), dtype=bool)

--- a/docs/cli/options.rst
+++ b/docs/cli/options.rst
@@ -143,10 +143,6 @@ The BSB's project-wide settings are all stored in ``pyproject.toml`` under ``too
   [tools.bsb]
   config = "network_configuration.json"
 
-  [tools.bsb.networks]
-  config_link = ["sys", "network_configuration.json", "always"]
-  morpho_link = ["sys", "morphologies.h5", "changes"]
-
 ========================
 Writing your own options
 ========================

--- a/docs/config/nodes.rst
+++ b/docs/config/nodes.rst
@@ -491,7 +491,7 @@ descriptor for the population attribute and define a ``__populate__`` method on 
     # Example that only stores referrers if their name in the configuration is "square".
     def __populate__(self, instance, value):
       print("We're referenced in", value.get_node_name())
-      if value.get_node_name().endswith("square"):
+      if value.get_node_name().endswith(".square"):
         self.__set__(instance, [value])
       else:
         print("We only store referrers coming from a .square configuration attribute")

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ NEURON==8.2.2
 nrn-subprocess==1.3.4
 
 # Plugins
-bsb-hdf5==0.6.1
+bsb-hdf5==0.6.2

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setuptools.setup(
     ],
     entry_points={
         "console_scripts": ["bsb = bsb.cli:handle_cli"],
+        "bsb.storage.engines": ["fs = bsb.storage.fs"],
         "bsb.simulation_backends": [
             "arbor = bsb.simulators.arbor",
             "nest = bsb.simulators.nest",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 requires = [
-    "bsb-hdf5~=0.6",
+    "bsb-hdf5~=0.6.2",
     "h5py~=3.0",
     "numpy~=1.19",
     "scipy~=1.5",

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ requires = [
     "requests",
     "appdirs~=1.4",
     "neo[nixio]",
+    "tqdm~=4.50.0",
 ]
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ requires = [
     "requests",
     "appdirs~=1.4",
     "neo[nixio]",
-    "tqdm~=4.50.0",
+    "tqdm~=4.50",
 ]
 
 setuptools.setup(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,8 +21,9 @@ class TestCLI(unittest.TestCase):
 
         # Test the default verbosity
         self.assertEqual(1, bsb.options.verbosity)
-        # Test that an option without script descriptor isn't registered
-        self.assertRaises(bsb.exceptions.OptionError, lambda: bsb.options.config)
+        # Test disabled because there's currently no options without script descr.
+        # # Test that an option without script descriptor isn't registered
+        # self.assertRaises(bsb.exceptions.OptionError, lambda: bsb.options.config)
 
     def test_env_descriptor(self):
         import os, bsb.options

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -14,7 +14,7 @@ from bsb.exceptions import (
     UnfitClassCastError,
     DynamicClassInheritanceError,
     UnresolvedClassCastError,
-    DynamicClassNotFoundError,
+    DynamicObjectNotFoundError,
     ClassMapMissingError,
 )
 from bsb.topology.region import RegionGroup
@@ -561,7 +561,7 @@ class TestDynamic(unittest.TestCase):
         )
         # Test that without the module path the same class can't be found
         self.assertRaises(
-            DynamicClassNotFoundError,
+            DynamicObjectNotFoundError,
             sys.modules["bsb.config._make"]._load_class,
             "NotInherited",
             [],

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -178,7 +178,7 @@ class TestScriptOption(unittest.TestCase):
         with self.assertRaises(ReadOnlyOptionError):
             self.opt["version"].script = "5.0"
         # Read one without bindings:
-        self.assertIsNone(self.opt["config"].script, "no bindings should be None")
+        self.assertIsNone(self.opt["version"].env, "no bindings should be None")
 
     def test_script_isset(self):
         script = type(self.opt["version"]).script
@@ -188,8 +188,9 @@ class TestScriptOption(unittest.TestCase):
     def test_script_set(self):
         self.opt["force"].script = True
         self.assertTrue(self.opt["force"].script, "script opt not set")
-        with self.assertRaises(OptionError, msg="no script binding opt may not set"):
-            self.opt["config"].script = True
+        #  No options without script descr atm
+        # with self.assertRaises(OptionError, msg="no script binding opt may not set"):
+        #     self.opt["config"].script = True
         self.assertTrue(self.opt["force"].get(), "script prio broken")
 
     def test_script_del(self):
@@ -216,8 +217,6 @@ class TestOptions(unittest.TestCase):
         cfg_opt = options.get_option("config")
         with self.assertRaises(OptionError):
             options.get_option("doesntexist")
-        with self.assertRaises(OptionError):
-            options.get_module_option("config")
 
     def test_discovery(self):
         cls = options.get_option_classes()
@@ -234,8 +233,6 @@ class TestOptions(unittest.TestCase):
     def test_options_set(self):
         options.verbosity = 2
         self.assertEqual(2, options.verbosity, "verbosity not set")
-        with self.assertRaises(OptionError):
-            options.config = 3
         # Clean up the script value we set for this test.
         del self.opt["verbosity"].script
         # Double reset shouldn't error
@@ -243,7 +240,7 @@ class TestOptions(unittest.TestCase):
 
     def test_set_module_option(self):
         with self.assertRaises(OptionError):
-            options.set_module_option("config", 3)
+            options.set_module_option("doesntexist", 3)
         options.set_module_option("verbosity", 3)
         del options.verbosity
         with self.assertRaises(AttributeError):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,39 +1,5 @@
 import unittest
-import os
-from bsb.core import Scaffold
-from bsb.config import from_json
-from bsb.storage import _util
-from bsb.unittest import get_config_path
-from bsb.services import MPI
-import pathlib
 
 
 class TestUtil(unittest.TestCase):
-    @classmethod
-    def tearDownClass(cls):
-        os.unlink(f"__dsgss__dd{MPI.get_rank()}.txt")
-
-    def test_links(self):
-        cfg = from_json(get_config_path("test_single"))
-        netw = Scaffold(cfg)
-        # Needs more tests, these tests basically only test instantiation
-        link = _util.link(netw.files, pathlib.Path.cwd(), "sys", "hellooo", "always")
-        link = _util.link(netw.files, pathlib.Path.cwd(), "cache", "hellooo", "always")
-        link = _util.link(netw.files, pathlib.Path.cwd(), "store", "hellooo", "always")
-        with self.assertRaises(ValueError):
-            _util.link("invalid", "oh", "invalid", "ah", "ah")
-        link = _util.syslink("hellooooo")
-        self.assertFalse(link.exists())
-        link = _util.storelink(netw.files, "iddd")
-        self.assertFalse(link.exists())
-        link = _util.nolink()
-        self.assertFalse(link.exists())
-        junk = f"__dsgss__dd{MPI.get_rank()}.txt"
-        with open(junk, "w") as f:
-            f.write("Your Highness?")
-        link = _util.syslink(junk)
-        self.assertTrue(link.exists())
-        with link.get() as f:
-            self.assertEqual("Your Highness?", f.read(), "message")
-        with link.get(binary=True) as f:
-            self.assertEqual("Your Highness?", f.read().decode("utf-8"), "message")
+    pass


### PR DESCRIPTION
## Describe the work done

File dependencies can now be specified using `config.file` which create `FileDependencyNode`s, that can keep a URI in sync with the internal file store of the model, allowing explicit file dependencies, to be processed by pipelines and updated whenever the URI scheme determines we ought to do so. Currently supported URI schemes are `file`, `http` and `https` (closes #345).

A `CodeDependencyNode` was added that allows you to specify `module.path` to resolve to `./module/path.py` (no `__init__.py` support for now) as a standalone module (so no parent package import either). A new `components` block was added to the config that can load any number of these code dependencies so that the components inside of them can be used without having to install any packages/plugins and user components can be loaded (closes #409, closes #398).

The Allen Structure Loader and other NRRD based nodes have all switched to the new file deps as well.

The `file_link` storage util has been superceded and removed, so no more "link" project settings, as all these functionalities have been replaced by better, automatic ways of achieving the same goal.

`CsvImportPlacement` and `CsvImportConnectivity` have been added (closes #650).

Several bugfixes:

* closes #663 
* closes #493 (automatic group region with all unmanaged partitions)
* closes #323.

## Tasks

* [ ] Added tests
* [ ] Updated documentation
