### PR TITLE
Add `InvertedRoI` mixin and `FixedIndegree` strategy

### DIFF
--- a/bsb/connectivity/general.py
+++ b/bsb/connectivity/general.py
@@ -120,6 +120,11 @@ class ExternalConnections(ConnectionStrategy):
 
 @config.node
 class FixedIndegree(InvertedRoI, ConnectionStrategy):
+    """
+    Connect a group of postsynaptic cell types to ``indegree`` uniformly random
+    presynaptic cells from all the presynaptic cell types.
+    """
+
     indegree = config.attr(type=int, required=True)
 
     def get_region_of_interest(self, chunk):

--- a/bsb/connectivity/general.py
+++ b/bsb/connectivity/general.py
@@ -135,7 +135,7 @@ class FixedIndegree(InvertedRoI, ConnectionStrategy):
         in_ = self.indegree
         rng = np.random.default_rng()
         high = sum(len(ps) for ps in pre.placement.values())
-        for post, ps in post.placement.items():
+        for post_ct, ps in post.placement.items():
             l = len(ps)
             pre_targets = np.full((l * in_, 3), -1)
             post_targets = np.full((l * in_, 3), -1)
@@ -145,7 +145,7 @@ class FixedIndegree(InvertedRoI, ConnectionStrategy):
                 pre_targets[ptr : ptr + in_, 0] = rng.choice(high, in_, replace=False)
                 ptr += in_
             lowmux = 0
-            for pre, pre_ps in pre.placement.items():
+            for pre_ct, pre_ps in pre.placement.items():
                 highmux = lowmux + len(pre_ps)
                 demux_idx = (pre_targets[:, 0] >= lowmux) & (pre_targets[:, 0] < highmux)
                 demuxed = pre_targets[demux_idx]

--- a/bsb/connectivity/strategy.py
+++ b/bsb/connectivity/strategy.py
@@ -90,8 +90,12 @@ class ConnectionStrategy(abc.ABC, SortableByAfter):
         return pre, post
 
     def connect_cells(self, pre_set, post_set, src_locs, dest_locs, tag=None):
+        if len(self.presynaptic.cell_types) > 1 or len(self.postsynaptic.cell_types) > 1:
+            name = f"{self.name}_{pre_set.cell_type.name}_to_{post_set.cell_type.name}"
+        else:
+            name = self.name
         cs = self.scaffold.require_connectivity_set(
-            pre_set.cell_type, post_set.cell_type, tag if tag is not None else self.name
+            pre_set.cell_type, post_set.cell_type, tag if tag is not None else name
         )
         cs.connect(pre_set, post_set, src_locs, dest_locs)
 

--- a/bsb/mixins.py
+++ b/bsb/mixins.py
@@ -60,3 +60,37 @@ class NotParallel:
                 "NotParallel can only be applied to placement or "
                 "connectivity strategies"
             )
+
+
+class InvertedRoI:
+    def queue(self, pool):
+        # Reset jobs that we own
+        self._queued_jobs = []
+        # Get the queued jobs of all the strategies we depend on.
+        deps = set(
+            itertools.chain.from_iterable(
+                strat._queued_jobs for strat in self.get_after()
+            )
+        )
+        post_types = self.postsynaptic.cell_types
+        # Iterate over each chunk that is populated by our postsynaptic cell types.
+        to_chunks = set(
+            itertools.chain.from_iterable(
+                ct.get_placement_set().get_all_chunks() for ct in post_types
+            )
+        )
+        rois = {
+            chunk: roi
+            for chunk in to_chunks
+            if (roi := self.get_region_of_interest(chunk))
+        }
+        if not rois:
+            warn(
+                f"No overlap found between {[post.name for post in post_types]} and "
+                f"{[pre.name for pre in self.presynaptic.cell_types]} "
+                f"in '{self.name}'."
+            )
+        for chunk, roi in rois.items():
+            job = pool.queue_connectivity(self, roi, [chunk], deps=deps)
+            self._queued_jobs.append(job)
+        report(f"Queued {len(self._queued_jobs)} jobs for {self.name}", level=2)

--- a/bsb/mixins.py
+++ b/bsb/mixins.py
@@ -63,6 +63,19 @@ class NotParallel:
 
 
 class InvertedRoI:
+    """
+    This mixin inverts the perspective of the ``get_region_of_interest`` interface and
+    lets you find presynaptic regions of interest for a postsynaptic chunk.
+
+    Usage:
+
+    ..code-block:: python
+
+        class MyConnStrat(InvertedRoI, ConnectionStrategy):
+          def get_region_of_interest(post_chunk):
+            return [pre_chunk1, pre_chunk2]
+    """
+
     def queue(self, pool):
         # Reset jobs that we own
         self._queued_jobs = []

--- a/bsb/unittest/data/configs/test_indegree.json
+++ b/bsb/unittest/data/configs/test_indegree.json
@@ -17,7 +17,7 @@
     "inhibitory": {
       "spatial": {
         "radius": 1.0,
-        "count": 500
+        "count": 2000
       }
     },
     "excitatory": {
@@ -29,7 +29,7 @@
     "extra": {
       "spatial": {
         "radius": 1.0,
-        "count": 500
+        "count": 2000
       }
     }
   },

--- a/bsb/unittest/data/configs/test_indegree.json
+++ b/bsb/unittest/data/configs/test_indegree.json
@@ -1,0 +1,52 @@
+{
+  "storage": {
+    "engine": "hdf5"
+  },
+  "network": {
+    "x": 150.0,
+    "y": 150.0,
+    "z": 150.0
+  },
+  "partitions": {
+    "all": {
+      "type": "layer",
+      "thickness": 150.0
+    }
+  },
+  "cell_types": {
+    "inhibitory": {
+      "spatial": {
+        "radius": 1.0,
+        "count": 500
+      }
+    },
+    "excitatory": {
+      "spatial": {
+        "radius": 1.0,
+        "count": 2000
+      }
+    }
+  },
+  "placement": {
+    "random": {
+      "strategy": "bsb.placement.RandomPlacement",
+      "cell_types": ["inhibitory","excitatory"],
+      "partitions": ["all"]
+    }
+  },
+  "connectivity": {
+    "indegree": {
+      "strategy": "bsb.connectivity.FixedIndegree",
+      "indegree": 50,
+      "presynaptic": {
+        "cell_types": ["excitatory"]
+      },
+      "postsynaptic": {
+        "cell_types": ["inhibitory"]
+      }
+    }
+  },
+  "simulations": {
+
+  }
+}

--- a/bsb/unittest/data/configs/test_indegree.json
+++ b/bsb/unittest/data/configs/test_indegree.json
@@ -25,12 +25,18 @@
         "radius": 1.0,
         "count": 2000
       }
+    },
+    "extra": {
+      "spatial": {
+        "radius": 1.0,
+        "count": 500
+      }
     }
   },
   "placement": {
     "random": {
       "strategy": "bsb.placement.RandomPlacement",
-      "cell_types": ["inhibitory","excitatory"],
+      "cell_types": ["inhibitory","excitatory", "extra"],
       "partitions": ["all"]
     }
   },
@@ -43,6 +49,16 @@
       },
       "postsynaptic": {
         "cell_types": ["inhibitory"]
+      }
+    },
+    "multi_indegree": {
+      "strategy": "bsb.connectivity.FixedIndegree",
+      "indegree": 50,
+      "presynaptic": {
+        "cell_types": ["excitatory", "extra"]
+      },
+      "postsynaptic": {
+        "cell_types": ["inhibitory", "extra"]
       }
     }
   },

--- a/docs/bsb/bsb.rst
+++ b/docs/bsb/bsb.rst
@@ -43,6 +43,13 @@ bsb.exceptions module
    :undoc-members:
    :show-inheritance:
 
+bsb.exceptions module
+---------------------
+
+.. automodule:: bsb.mixins
+   :members:
+   :undoc-members:
+
 bsb.option module
 -----------------
 

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -655,3 +655,21 @@ class TestFixedIndegree(
             "Not all post cells have connections",
         )
         self.assertTrue(np.all(c == 50), "Not all cells have indegree 50")
+
+    def test_multi_indegree(self):
+        self.network.compile()
+        for post_name in ("inhibitory", "extra"):
+            total = np.zeros(len(self.network.get_placement_set(post_name)))
+            for pre_name in ("excitatory", "extra"):
+                cs = self.network.get_connectivity_set(
+                    f"multi_indegree_{pre_name}_to_{post_name}"
+                )
+                _, post_locs = cs.load_connections().all()
+                ps = self.network.get_placement_set("inhibitory")
+                u, c = np.unique(post_locs[:, 0], return_counts=True)
+                self.assertTrue(
+                    np.array_equal(np.arange(len(ps)), np.sort(u)),
+                    "Not all post cells have connections",
+                )
+                total += c
+            self.assertTrue(np.all(total == 50), "Not all cells have indegree 50")

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -659,7 +659,8 @@ class TestFixedIndegree(
     def test_multi_indegree(self):
         self.network.compile()
         for post_name in ("inhibitory", "extra"):
-            total = np.zeros(len(self.network.get_placement_set(post_name)))
+            post_ps = self.network.get_placement_set(post_name)
+            total = np.zeros(len(post_ps))
             for pre_name in ("excitatory", "extra"):
                 cs = self.network.get_connectivity_set(
                     f"multi_indegree_{pre_name}_to_{post_name}"
@@ -667,9 +668,7 @@ class TestFixedIndegree(
                 _, post_locs = cs.load_connections().all()
                 ps = self.network.get_placement_set("inhibitory")
                 u, c = np.unique(post_locs[:, 0], return_counts=True)
-                self.assertTrue(
-                    np.array_equal(np.arange(len(ps)), np.sort(u)),
-                    "Not all post cells have connections",
-                )
-                total += c
+                this = np.zeros(len(post_ps))
+                this[u] = c
+                total += this
             self.assertTrue(np.all(total == 50), "Not all cells have indegree 50")


### PR DESCRIPTION
## Describe the work done

The `InvertedRoI` mixin lets users make strategies that look for the presynaptic RoI of a post chunk, rather than the postsynaptic RoI of a pre chunk.

The `FixedIndegree` strategy connects cell populations with a fixed number of random presynaptic targets for each postsynaptic target.

## Tasks

* [x] Added tests
* [ ] Updated documentation
