### PR TITLE
Fix numpy arrays in `JsonParser.generate`, add `format_content` utility

### DIFF
--- a/bsb/config/__init__.py
+++ b/bsb/config/__init__.py
@@ -153,6 +153,9 @@ class ConfigurationModule:
         parser, tree, meta = _try_parsers(content, self._parser_classes, ext, path=path)
         return _from_parsed(self, parser, tree, meta, path)
 
+    def generate_config(self, parser_name, config):
+        return self.get_parser(parser_name).generate(config.__tree__(), pretty=True)
+
     __all__ = [*(vars().keys() - {"__init__", "__qualname__", "__module__"})]
 
 

--- a/bsb/config/__init__.py
+++ b/bsb/config/__init__.py
@@ -140,6 +140,9 @@ class ConfigurationModule:
         copy_file(files[0], output)
 
     def from_file(self, file):
+        """
+        Create a configuration object from a path or file-like object.
+        """
         if not hasattr(file, "read"):
             with open(file, "r") as f:
                 return self.from_file(f)
@@ -149,11 +152,17 @@ class ConfigurationModule:
         return self.from_content(file.read(), path)
 
     def from_content(self, content, path=None):
+        """
+        Create a configuration object from a content string
+        """
         ext = path.split(".")[-1] if path is not None else None
         parser, tree, meta = _try_parsers(content, self._parser_classes, ext, path=path)
         return _from_parsed(self, parser, tree, meta, path)
 
-    def generate_config(self, parser_name, config):
+    def format_content(self, parser_name, config):
+        """
+        Convert a configuration object to a string using the given parser.
+        """
         return self.get_parser(parser_name).generate(config.__tree__(), pretty=True)
 
     __all__ = [*(vars().keys() - {"__init__", "__qualname__", "__module__"})]

--- a/bsb/config/parsers/json.py
+++ b/bsb/config/parsers/json.py
@@ -4,6 +4,7 @@ references.
 """
 
 import json
+import numpy as np
 import os
 from ...exceptions import JsonImportError, ConfigurationWarning, JsonReferenceError
 from ...reporting import warn
@@ -142,6 +143,13 @@ class json_imp(json_ref):
                 self.node[key] = target[key]
 
 
+def _to_json(value):
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    else:
+        raise TypeError()
+
+
 class JsonParser(Parser):
     """
     Parser plugin class to parse JSON configuration files.
@@ -173,9 +181,9 @@ class JsonParser(Parser):
 
     def generate(self, tree, pretty=False):
         if pretty:
-            return json.dumps(tree, indent=4)
+            return json.dumps(tree, indent=4, default=_to_json)
         else:
-            return json.dumps(tree)
+            return json.dumps(tree, default=_to_json)
 
     def _traverse(self, node, iter):
         # Iterates over all values in `iter` and checks for import keys, recursion or refs


### PR DESCRIPTION
Any configuration node can now be parsed and formatted into a string using `bsb.config.format_content(parser_name, node)`
