### PR TITLE
Add missing signatures for the MorphologyRepository metadata access.

### DIFF
--- a/bsb/storage/interfaces.py
+++ b/bsb/storage/interfaces.py
@@ -811,6 +811,24 @@ class MorphologyRepository(Interface, engine_key="morphologies"):
         """
         pass
 
+    @abc.abstractmethod
+    def get_all_meta(self):
+        """
+        Get the metadata of all stored morphologies.
+        :returns: Metadata dictionary
+        :rtype: dict
+        """
+        pass
+
+    @abc.abstractmethod
+    def set_all_meta(self, all_meta):
+        """
+        Set the metadata of all stored morphologies.
+        :param all_meta: Metadata dictionary.
+        :type all_meta: dict
+        """
+        pass
+
     def import_swc(self, file, name=None, overwrite=False):
         """
         Import and store .swc file contents as a morphology in the repository.


### PR DESCRIPTION
With the recent changes of the morphology metadata handling, some signatures of MorphologyRepository were missing.
These functions are used in bsb.placement.distributor.py