### PR TITLE
Fix/str safe

### DIFF
--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -484,7 +484,9 @@ class ConfigurationAttribute:
             else:
                 t = builtins.type(self.default)
         else:
-            t = type or str
+            from . import types
+
+            t = type or types.str()
         # This call wraps the type handler so that it accepts all reserved keyword args
         # like `_parent` and `_key`
         t = _wrap_reserved(t)

--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -486,7 +486,7 @@ class ConfigurationAttribute:
         else:
             from . import types
 
-            t = type or types.str(safe=False)
+            t = type or types.str()
         # This call wraps the type handler so that it accepts all reserved keyword args
         # like `_parent` and `_key`
         t = _wrap_reserved(t)

--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -195,7 +195,7 @@ def attr(**kwargs):
     """
     Create a configuration attribute.
 
-    Only works when used inside of a class decorated with the :func:`node
+    Only works when used inside a class decorated with the :func:`node
     <.config.node>`, :func:`dynamic <.config.dynamic>`,  :func:`root <.config.root>`
     or  :func:`pluggable <.config.pluggable>` decorators.
 
@@ -486,7 +486,7 @@ class ConfigurationAttribute:
         else:
             from . import types
 
-            t = type or types.str()
+            t = type or types.str(safe=False)
         # This call wraps the type handler so that it accepts all reserved keyword args
         # like `_parent` and `_key`
         t = _wrap_reserved(t)

--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -429,7 +429,7 @@ class ConfigurationAttribute:
         self.key = key
         self.default = default
         self.call_default = call_default
-        self.type = self._set_type(type)
+        self.type = self._set_type(type, key)
         self.unset = unset
         self.hint = hint
 
@@ -475,7 +475,7 @@ class ConfigurationAttribute:
         if _is_booted(root):
             _boot_nodes(value, root.scaffold)
 
-    def _set_type(self, type):
+    def _set_type(self, type, key):
         self._config_type = type
         # Determine type of the attribute
         if not type and self.default is not None:
@@ -486,7 +486,7 @@ class ConfigurationAttribute:
         else:
             from . import types
 
-            t = type or types.str()
+            t = type or (key and types.key()) or types.str()
         # This call wraps the type handler so that it accepts all reserved keyword args
         # like `_parent` and `_key`
         t = _wrap_reserved(t)
@@ -669,8 +669,8 @@ class ConfigurationListAttribute(ConfigurationAttribute):
             )
         return _cfglist
 
-    def _set_type(self, type):
-        self.child_type = super()._set_type(type)
+    def _set_type(self, type, key=None):
+        self.child_type = super()._set_type(type, key=False)
         return self.fill
 
     def tree(self, instance):
@@ -809,8 +809,8 @@ class ConfigurationDictAttribute(ConfigurationAttribute):
         _cfgdict.update(value or builtins.dict())
         return _cfgdict
 
-    def _set_type(self, type):
-        self.child_type = super()._set_type(type)
+    def _set_type(self, type, key=None):
+        self.child_type = super()._set_type(type, key=False)
         return self.fill
 
     def tree(self, instance):

--- a/bsb/config/types.py
+++ b/bsb/config/types.py
@@ -422,6 +422,25 @@ def number(min=None, max=None):
     return type_handler
 
 
+def key():
+    """
+    Type handler for keys in configuration trees. Keys can be either int indices of a
+    config list, or string keys of a config dict.
+
+    :returns: Type validator function
+    :rtype: Callable
+    """
+
+    def type_handler(value):
+        if not isinstance(value, builtins.int) or isinstance(value, builtins.str):
+            raise TypeError(f"{type(value)} is not an int or str")
+        else:
+            return value
+
+    type_handler.__name__ = "configuration key"
+    return type_handler
+
+
 def scalar_expand(scalar_type, size=None, expand=None):
     """
     Create a method that expands a scalar into an array with a specific size or uses

--- a/bsb/config/types.py
+++ b/bsb/config/types.py
@@ -432,7 +432,7 @@ def key():
     """
 
     def type_handler(value):
-        if not isinstance(value, builtins.int) or isinstance(value, builtins.str):
+        if not (isinstance(value, builtins.int) or isinstance(value, builtins.str)):
             raise TypeError(f"{type(value)} is not an int or str")
         else:
             return value

--- a/bsb/config/types.py
+++ b/bsb/config/types.py
@@ -276,9 +276,9 @@ class method_shortcut(method, function_):
             return value
 
 
-def str(strip=False, lower=False, upper=False):
+def str(strip=False, lower=False, upper=False, safe=True):
     """
-    Type validator. Attempts to cast the value to an str, optionally with some sanitation.
+    Type validator. Attempts to cast the value to a str, optionally with some sanitation.
 
     :param strip: Trim whitespaces
     :type strip: bool
@@ -286,13 +286,16 @@ def str(strip=False, lower=False, upper=False):
     :type lower: bool
     :param upper: Convert value to uppercase
     :type upper: bool
+    :param safe: If False, checks that the type of value is string before cast.
+    :type safe: bool
     :returns: Type validator function
     :raises: TypeError when value can't be cast.
     :rtype: Callable
     """
     handler_name = "str"
     # Compile a custom function to sanitize the string according to args
-    fstr = "def f(s): return str(s)"
+    safety_check = "\n if not isinstance(s, str):\n  raise TypeError()\n" if safe else ""
+    fstr = f"def f(s):{safety_check} return str(s)"
     for add, mod in zip((strip, lower, upper), ("strip", "lower", "upper")):
         if add:
             fstr += f".{mod}()"

--- a/bsb/storage/_files.py
+++ b/bsb/storage/_files.py
@@ -474,7 +474,7 @@ class MorphologyDependencyNode(FilePipelineMixin, FileDependencyNode):
     Name associated to the morphology. If not provided, the program will use the name of the file 
     in which the morphology is stored. 
     """
-    tags = config.attr(type=types.dict(type=types.or_(str, types.list(str))))
+    tags = config.attr(type=types.dict(type=types.or_(types.str(), types.list(str))))
     """
     Dictionary mapping SWC tags to sets of morphology labels.
     """

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -248,7 +248,7 @@ class TestConfigList(unittest.TestCase):
     def test_list_attr(self):
         @config.node
         class Child:
-            index = config.attr(type=int, key=True)
+            index = config.attr(key=True)
             name = config.attr(type=str, required=True)
 
         @config.node

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -248,7 +248,7 @@ class TestConfigList(unittest.TestCase):
     def test_list_attr(self):
         @config.node
         class Child:
-            index = config.attr(key=True)
+            index = config.attr(type=int, key=True)
             name = config.attr(type=str, required=True)
 
         @config.node
@@ -1143,7 +1143,7 @@ class TestTreeing(unittest.TestCase):
         class Test:
             a = config.attr(default=5)
             b = config.attr(type=float)
-            c = config.attr()
+            c = config.attr(type=types.str(safe=False))
 
         cfg = Test({"a": "5", "b": "5.", "c": 3})
         test_tree = cfg.__tree__()

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -26,7 +26,7 @@ class Example:
 
 @config.node
 class Extension:
-    ex_mut = config.attr(required=True)
+    ex_mut = config.attr(type=int, required=True)
     ref = config.ref(BothReference(), required=True)
 
 


### PR DESCRIPTION
Add safe flag to types.str to prevent default casting. The default attribute type remains however unsafe to keep the default old behavior. 

closes #737