### PR TITLE
Separated the `docs` deps, and renamed `mpi` deps to `parallel`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         # Install latest pip
         pip install --upgrade pip
         # Install bsb-core
-        pip install .[test,mpi]
+        pip install .[test,parallel]
 
     - name: Run tests & coverage
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.11.0
     hooks:
       - id: black
         language_version: python3

--- a/bsb/__init__.py
+++ b/bsb/__init__.py
@@ -7,7 +7,7 @@ which are essential for `bsb-core` to function. First time users are recommended
 install the `bsb` package instead.
 """
 
-__version__ = "4.0.0b1"
+__version__ = "4.0.0b2"
 
 import functools
 

--- a/bsb/services/mpi.py
+++ b/bsb/services/mpi.py
@@ -54,9 +54,13 @@ class MPIModule(MockModule):
     @property
     @functools.cache
     def COMM_WORLD(self):
-        if any("mpi" in key.lower() for key in os.environ):
+        if (
+            any("mpi" in key.lower() for key in os.environ)
+            and "BSB_IGNORE_PARALLEL" not in os.environ
+        ):
             raise DependencyError(
-                "MPI execution detected without MPI dependencies."
-                + " Please install with `pip install bsb[mpi]` to use MPI."
+                "MPI runtime detected without parallel support."
+                + " Please install with `pip install bsb[parallel]`."
+                + " Set `BSB_IGNORE_PARALLEL` to ignore this error."
             )
         return None

--- a/docs/dev/documentation.rst
+++ b/docs/dev/documentation.rst
@@ -2,13 +2,13 @@
 Documentation
 #############
 
-Install the developer requirements of the BSB:
+Install the documentation dependencies of the BSB:
 
 .. code-block:: bash
 
-  pip install -e .[dev]
+  pip install -e .[docs]
 
-Then from the ``docs`` directory run:
+Then navigate to the ``docs`` directory and run:
 
 .. code-block:: bash
 

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -43,28 +43,30 @@ On Windows, install `Microsoft MPI
 <https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi>`_. On
 supercomputers it is usually installed already, otherwise contact your administrator.
 
-To then install the BSB with MPI support:
+To then install the BSB with parallel MPI support:
 
 .. code-block:: bash
 
-  pip install "bsb[mpi]>=4.0.0a0"
+  pip install "bsb[parallel]>=4.0.0b0"
 
 Simulator backends
 ==================
 
 If you'd like to install the scaffold builder for point neuron simulations with
-NEST or multicompartmental neuron simulations with NEURON use:
+NEST or multicompartmental neuron simulations with NEURON or Arbor use:
 
 .. code-block:: bash
 
   pip install bsb[nest]
   # or
+  pip install bsb[arbor]
+  # or
   pip install bsb[neuron]
-  # or both
-  pip install bsb[nest,neuron]
+  # or any combination
+  pip install bsb[arbor,nest,neuron]
 
 .. note::
 
   This does not install the simulators themselves. It installs the Python tools that the
-  BSB needs to deal with them. Install the simulators separately according to their
+  BSB needs to support them. Install the simulators separately according to their
   respective installation instructions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,28 +59,28 @@ profiling = "bsb._options:profiling"
 
 [project.optional-dependencies]
 parallel = [
-    "mpi4py~=3.0.0",
-    "zwembad~=1.2.2",
-    "mpilock~=1.1.0"
+    "mpi4py~=3.0",
+    "zwembad~=1.2",
+    "mpilock~=1.1"
 ]
 test = [
-    "coverage~=7.3.0",
+    "coverage~=7.3",
     "bsb-hdf5==1.0.0b1",
     "bsb-test==0.0.0b0",
     "bsb-json==0.0.0b0"
 ]
 docs = [
-    "sphinx~=7.0.0",
-    "furo~=2023.9.10",
+    "sphinx~=7.0",
+    "furo~=2023.9",
     "sphinxemoji~=0.2.0",
     "sphinx_design~=0.5.0",
     "sphinx-copybutton~=0.5.0",
     "sphinxext-bsb~=0.2.1"
 ]
 dev = [
-    "pre-commit~=3.5.0",
-    "black~=23.11.0",
-    "snakeviz~=2.1.0"
+    "pre-commit~=3.5",
+    "black~=23.11",
+    "snakeviz~=2.1"
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,25 +58,30 @@ config = "bsb._options:config"
 profiling = "bsb._options:profiling"
 
 [project.optional-dependencies]
+parallel = [
+    "mpi4py~=3.0.0",
+    "zwembad~=1.2.2",
+    "mpilock~=1.1.0"
+]
 test = [
     "coverage~=7.3.0",
     "bsb-hdf5==1.0.0b1",
     "bsb-test==0.0.0b0",
     "bsb-json==0.0.0b0"
 ]
-dev = [
-    "sphinx~=7.0",
-    "furo",
-    "pre-commit",
-    "black~=22.3.0",
-    "nrn-subprocess~=1.3.4",
-    "sphinxemoji",
-    "sphinx_design~=0.5",
-    "sphinx-copybutton~=0.5",
-    "sphinxext-bsb~=0.2.1",
-    "snakeviz",
+docs = [
+    "sphinx~=7.0.0",
+    "furo~=2023.9.10",
+    "sphinxemoji~=0.2.0",
+    "sphinx_design~=0.5.0",
+    "sphinx-copybutton~=0.5.0",
+    "sphinxext-bsb~=0.2.1"
 ]
-mpi = ["mpi4py~=3.0", "zwembad", "mpilock~=1.1"]
+dev = [
+    "pre-commit~=3.5.0",
+    "black~=23.11.0",
+    "snakeviz~=2.1.0"
+]
 
 [tool.black]
 line-length = 90


### PR DESCRIPTION
## Describe the work done

A couple of different developer dependencies were all clumped together, and the `mpi` dependency might not be clear enough for people who want to parallelize their code, but are unfamiliar with MPI.

## Tasks

* [x] Updated documentation

@filimarc Please review whether you think this is a positive change, and whether you can think of any places where this has an impact that I may have overlooked :)