### PR TITLE
Run simulation tests using `bsb-arbor` as it is pip installable and robust

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ test = [
     "coverage~=7.3",
     "bsb-hdf5==1.0.0b1",
     "bsb-test==0.0.0b0",
-    "bsb-json==0.0.0b0"
+    "bsb-json==0.0.0b0",
+    "bsb-arbor==0.0.0b0"
 ]
 docs = [
     "sphinx~=7.0",

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -5,7 +5,6 @@ from bsb_test import FixedPosConfigFixture, NumpyTestCase, RandomStorageFixture
 from bsb.core import Scaffold
 
 
-@unittest.skip("todo: Move this test from bsb-core to bsb")
 class TestSimulate(
     FixedPosConfigFixture,
     RandomStorageFixture,
@@ -29,7 +28,7 @@ class TestSimulate(
     def test_simulate(self):
         self.network.simulations.add(
             "test",
-            simulator="nest",
+            simulator="arbor",
             duration=100,
             resolution=1.0,
             cell_models=dict(),


### PR DESCRIPTION
To test that simulation adapters work in general, I re-enabled a test using `bsb-arbor`
