### PR TITLE
Added version bumping & release dev docs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 current_version = 4.0.0b1
-files = __init__.py
+files = bsb/__init__.py
 commit = False
 parse = ^
         (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,33 @@
+[bumpversion]
+current_version = 4.0.0b1
+files = __init__.py
+commit = False
+parse = ^
+        (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+        (\.(?P<prekind>a|alpha|b|beta|d|dev|rc)
+        (?P<pre>\d+)  # pre-release version num
+        )?
+        (\.(?P<postkind>post)(?P<post>\d+))?  # post-release
+serialize =
+        {major}.{minor}.{patch}.{prekind}{pre}.{postkind}{post}
+        {major}.{minor}.{patch}.{prekind}{pre}
+        {major}.{minor}.{patch}.{postkind}{post}
+        {major}.{minor}.{patch}
+
+[bumpversion:part:prekind]
+optional_value = _
+values =
+    _
+    dev
+    d
+    alpha
+    a
+    beta
+    b
+    rc
+
+[bumpversion:part:postkind]
+optional_value = _
+values =
+    _
+    post

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,33 +1,34 @@
 [bumpversion]
 current_version = 4.0.0.b2
 files = bsb/__init__.py
-commit = False
+commit = True
+tag = True
 parse = ^
-        (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-        (\.(?P<prekind>a|alpha|b|beta|d|dev|rc)
-        (?P<pre>\d+)  # pre-release version num
-        )?
-        (\.(?P<postkind>post)(?P<post>\d+))?  # post-release
-serialize =
-        {major}.{minor}.{patch}.{prekind}{pre}.{postkind}{post}
-        {major}.{minor}.{patch}.{prekind}{pre}
-        {major}.{minor}.{patch}.{postkind}{post}
-        {major}.{minor}.{patch}
+	(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+	(\.(?P<prekind>a|alpha|b|beta|d|dev|rc)
+	(?P<pre>\d+)  # pre-release version num
+	)?
+	(\.(?P<postkind>post)(?P<post>\d+))?  # post-release
+serialize = 
+	{major}.{minor}.{patch}.{prekind}{pre}.{postkind}{post}
+	{major}.{minor}.{patch}.{prekind}{pre}
+	{major}.{minor}.{patch}.{postkind}{post}
+	{major}.{minor}.{patch}
 
 [bumpversion:part:prekind]
 optional_value = _
-values =
-    _
-    dev
-    d
-    alpha
-    a
-    beta
-    b
-    rc
+values = 
+	_
+	dev
+	d
+	alpha
+	a
+	beta
+	b
+	rc
 
 [bumpversion:part:postkind]
 optional_value = _
-values =
-    _
-    post
+values = 
+	_
+	post

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.0.0b1
+current_version = 4.0.0.b2
 files = bsb/__init__.py
 commit = False
 parse = ^

--- a/bsb/__init__.py
+++ b/bsb/__init__.py
@@ -7,7 +7,7 @@ which are essential for `bsb-core` to function. First time users are recommended
 install the `bsb` package instead.
 """
 
-__version__ = "4.0.0b2"
+__version__ = "4.0.0.b2"
 
 import functools
 

--- a/docs/dev/installation.rst
+++ b/docs/dev/installation.rst
@@ -4,8 +4,8 @@ Developer Installation
 
 To install::
 
-  git clone git@github.com:dbbs-lab/bsb
-  cd bsb
+  git clone git@github.com:dbbs-lab/bsb-core
+  cd bsb-core
   pip install -e .[dev]
   pre-commit install
 
@@ -13,3 +13,12 @@ To install::
 Test your install with::
 
   python -m unittest discover -s tests
+
+Releases
+--------
+
+To release a new version::
+
+  bump2version pre
+  python -m build
+  twine upload dist/* --skip-existing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,13 @@ docs = [
     "sphinxext-bsb~=0.2.1"
 ]
 dev = [
+    "build~=1.0",
+    "twine~=4.0",
     "pre-commit~=3.5",
     "black~=23.11",
     "isort~=5.12",
-    "snakeviz~=2.1"
+    "snakeviz~=2.1",
+    "bump2version~=1.0"
 ]
 
 [tool.black]


### PR DESCRIPTION
I added `bump2version` to the repo so that we can easily bump the version in `bsb/__init__.py`

<!-- readthedocs-preview bsb start -->
----
📚 Documentation preview 📚: https://bsb--793.org.readthedocs.build/en/793/

<!-- readthedocs-preview bsb end -->