### PR TITLE
Small Fixes in tests 

### DIFF
--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -466,7 +466,7 @@ class ConfigurationAttribute:
                 f"Couldn't cast '{value}' into {self.type.__name__}: {e}",
                 instance,
                 self.attr_name,
-            )
+            ) from e
         # The value was cast to its intented type and the new value can be set.
         _setattr(instance, self.attr_name, value)
         root = _strict_root(instance)

--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -2,7 +2,6 @@
     An attrs-inspired class annotation system, but my A stands for amateuristic.
 """
 import builtins
-import traceback
 
 import errr
 
@@ -463,7 +462,6 @@ class ConfigurationAttribute:
                 e.node, e.attr = instance, self.attr_name
             raise
         except Exception as e:
-            traceback.print_exc()
             raise CastError(
                 f"Couldn't cast '{value}' into {self.type.__name__}: {e}",
                 instance,

--- a/tests/test_chunks.py
+++ b/tests/test_chunks.py
@@ -1,8 +1,9 @@
 import unittest
 
 import numpy as np
-from bsb_test import NumpyTestCase, skip_parallel, timeout
+from bsb_test import NumpyTestCase, get_config_path, skip_parallel, timeout
 
+from bsb.config import from_json
 from bsb.core import Scaffold
 from bsb.storage import Chunk
 
@@ -32,8 +33,7 @@ class TestChunks(unittest.TestCase, NumpyTestCase):
     # basic chunk properties. For example uses `.place` directly.
     def test_single_chunk(self):
         # Test that specifying a single chunk only reads the data from that chunk
-        from bsb_test.pyconfig import cfg_single
-
+        cfg_single = from_json(get_config_path("test_single"))
         self.network = network = Scaffold(cfg_single, clear=True)
         self.ps = ps = network.get_placement_set("test_cell")
         ps.include_chunk(Chunk((0, 0, 0), None))


### PR DESCRIPTION
* Fix test_chunks.py configuration

* Remove duplicated exception printing in case of failed node attribute casting.
