### PR TITLE
Enhance error feedback with strategy class for Connettivity and Placement

### DIFF
--- a/bsb/placement/indicator.py
+++ b/bsb/placement/indicator.py
@@ -122,13 +122,15 @@ class PlacementIndicator:
                 else:
                     raise PlacementRelationError(
                         "%cell_type.name% requires relation %relation.name%"
-                        + "to specify density information.",
+                        + "to specify density information. In %placement.name% placement using %placement.strategy%.",
                         self.cell_type,
                         relation,
+                        self._strat.name,
+                        self._strat.strategy,
                     )
             else:
                 raise PlacementError(
-                    "Relation specified but no ratio indications provided."
+                    f"In {self._strat.name} using {self._strat.strategy} Relation is specified but no ratio indications provided."
                 )
         if density_key is not None:
             if voxels is None:

--- a/bsb/placement/particle.py
+++ b/bsb/placement/particle.py
@@ -235,11 +235,11 @@ class ParticleSystem:
                 count, pvol, vol = self._get_packing_factors()
                 raise PackingError(
                     f"{msg}. Can not fit {round(count)} particles for a total of "
-                    f"{round(pvol, 3)}μm³ micrometers into {round(vol, 3)}μm³."
+                    f"{round(pvol, 3)}μm³ micrometers into {round(vol, 3)}μm³ using strategy {strat_name} for {self.strat.name}."
                 )
             elif pf > 0.2:
                 warn(
-                    f"{msg} is too high for good {strat_name} performance.",
+                    f"{msg} is too high for good {strat_name} performance in {self.strat.name}.",
                     PackingWarning,
                 )
         # Reset particles
@@ -257,7 +257,7 @@ class ParticleSystem:
         radius = particle_type["radius"]
         if len(voxel_counts) != len(self.voxels):
             raise Exception(
-                f"Particle system voxel mismatch. Given {len(voxel_counts)} expected {len(self.voxels)}"
+                f"In {self.strat.name} using {self.strat.strategy} particle system voxel mismatch. Given {len(voxel_counts)} expected {len(self.voxels)}"
             )
         for voxel, count in zip(self.voxels, voxel_counts):
             particle_type["placed"] = particle_type.get("placed", 0) + count
@@ -395,7 +395,7 @@ class ParticleSystem:
             )
             if expansions > 100:
                 raise Exception(
-                    f"ERROR! Unable to find suited neighbourhood around {epicenter}"
+                    f"ERROR! Unable to find suited neighbourhood around {epicenter}. In {self.strat.name} using {self.strat.strategy}"
                 )
         return Neighbourhood(
             epicenter, neighbours, neighbourhood_radius, partners, partner_radius
@@ -676,7 +676,7 @@ class AdaptiveNeighbourhood(ParticleSystem):
             neighbourhood_ok = neighbourhood_packing_factor < 0.5
             if expansions > 100:
                 raise Exception(
-                    f"ERROR! Unable to find suited neighbourhood around {epicenter}"
+                    f"ERROR! Unable to find suited neighbourhood around {epicenter} for {self.strat.name} placement using {self.strat.strategy}"
                 )
 
         return Neighbourhood(

--- a/bsb/placement/strategy.py
+++ b/bsb/placement/strategy.py
@@ -169,7 +169,7 @@ class FixedPositions(PlacementStrategy):
     def place(self, chunk, indicators):
         if self.positions is None:
             raise ValueError(
-                f"Please set `.positions` on '{self.name}' before placement."
+                f"Please set `.positions` on '{self.name}' before placement for '{self.strategy}'."
             )
         for indicator in indicators.values():
             inside_chunk = VoxelSet([chunk], chunk.dimensions).inside(self.positions)
@@ -177,12 +177,16 @@ class FixedPositions(PlacementStrategy):
 
     def guess_cell_count(self):
         if self.positions is None:
-            raise ValueError(f"Please set `.positions` on '{self.name}'.")
+            raise ValueError(
+                f"Please set `.positions` on '{self.name}' for '{self.strategy}'."
+            )
         return len(self.positions)
 
     def queue(self, pool, chunk_size):
         if self.positions is None:
-            raise ValueError(f"Please set `.positions` on '{self.name}'.")
+            raise ValueError(
+                f"Please set `.positions` on '{self.name}' for '{self.strategy}'."
+            )
         # Reset jobs that we own
         self._queued_jobs = []
         # Get the queued jobs of all the strategies we depend on.


### PR DESCRIPTION
Adding the name and class of the strategy used in the error messages of Connectivity and Placement.

## List which issues this resolves:

closes #761 

## Tasks

* [X] Added tests
* [ ] Updated documentation
