### PR TITLE
Assert package requirements

### DIFF
--- a/bsb/_package_spec.py
+++ b/bsb/_package_spec.py
@@ -1,0 +1,60 @@
+from exceptiongroup import ExceptionGroup
+
+from bsb.exceptions import PackageRequirementWarning
+from bsb.reporting import warn
+
+
+class MissingRequirementErrors(ExceptionGroup):
+    pass
+
+
+def get_missing_requirement_reason(package):
+    from importlib.metadata import PackageNotFoundError, version
+
+    from packaging.requirements import InvalidRequirement, Requirement
+
+    try:
+        req = Requirement(package)
+    except InvalidRequirement:
+        return f"Can't check package requirement '{package}': invalid requirement"
+    try:
+        ver = version(req.name)
+    except PackageNotFoundError:
+        return f"Missing package '{req.name}'. You may experience errors or differences in results."
+    else:
+        if not ver in req.specifier:
+            return (
+                f"Installed version of '{req.name}' ({ver}) "
+                f"does not match requirements: '{req}'. You may experience errors or differences in results."
+            )
+
+
+def get_missing_packages(packages):
+    return [
+        package
+        for package in packages
+        if get_missing_requirement_reason(package) is not None
+    ]
+
+
+def get_unmet_package_reasons(packages):
+    return [
+        reason
+        for package in packages
+        if (reason := get_missing_requirement_reason(package)) is not None
+    ]
+
+
+def warn_missing_packages(packages):
+    for warning in get_unmet_package_reasons(packages):
+        warn(warning, PackageRequirementWarning)
+
+
+def raise_missing_packages(packages):
+    raise MissingRequirementErrors(
+        "Your model is missing requirement(s)",
+        [
+            PackageRequirementWarning(warning)
+            for warning in get_unmet_package_reasons(packages)
+        ],
+    )

--- a/bsb/config/__init__.py
+++ b/bsb/config/__init__.py
@@ -252,10 +252,6 @@ def _try_parsers(content, classes, ext=None, path=None):  # pragma: nocover
 
 
 def _from_parsed(self, parser_name, tree, meta, file=None):
-    if "components" in tree:
-        from ._config import _bootstrap_components
-
-        _bootstrap_components(tree["components"])
     conf = self.Configuration(tree)
     conf._parser = parser_name
     conf._meta = meta

--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -503,9 +503,11 @@ class ConfigurationAttribute:
         return self._config_type
 
     def get_hint(self):
+        if self.hint is not MISSING:
+            return self.hint
         if hasattr(self.type, "__hint__"):
             return self.type.__hint__()
-        return self.hint
+        return MISSING
 
     def get_node_name(self, instance):
         return instance.get_node_name() + "." + self.attr_name
@@ -691,6 +693,13 @@ class ConfigurationListAttribute(ConfigurationAttribute):
         val = _getattr(instance, self.attr_name)
         return [self.tree_of(e) for e in val]
 
+    def get_hint(self):
+        if self.hint is not MISSING:
+            return self.hint
+        if hasattr(self.child_type, "__hint__"):
+            return [self.child_type.__hint__(), self.child_type.__hint__()]
+        return MISSING
+
 
 class cfgdict(builtins.dict):
     """
@@ -834,6 +843,16 @@ class ConfigurationDictAttribute(ConfigurationAttribute):
     def tree(self, instance):
         val = _getattr(instance, self.attr_name).items()
         return {k: self.tree_of(v) for k, v in val}
+
+    def get_hint(self):
+        if self.hint is not MISSING:
+            return self.hint
+        if hasattr(self.child_type, "__hint__"):
+            return {
+                "key1": self.child_type.__hint__(),
+                "key2": self.child_type.__hint__(),
+            }
+        return MISSING
 
 
 class ConfigurationReferenceAttribute(ConfigurationAttribute):

--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -394,6 +394,7 @@ def _boot_nodes(top_node, scaffold):
             run_hook(node, "boot")
         except Exception as e:
             errr.wrap(BootError, e, prepend=f"Failed to boot {node}:")
+    # fixme: why is this here? Will deadlock in case of BootError on specific node only.
     MPI.barrier()
 
 

--- a/bsb/config/_config.py
+++ b/bsb/config/_config.py
@@ -20,7 +20,7 @@ from . import types
 from ._attrs import _boot_nodes, cfgdict, cfglist
 
 if typing.TYPE_CHECKING:
-    from packaging.requirements import Requirement
+    import packaging.requirements
 
     from ..core import Scaffold
 
@@ -65,35 +65,63 @@ class Configuration:
     components: cfglist[CodeDependencyNode] = config.list(
         type=CodeDependencyNode,
     )
-    packages: cfglist["Requirement"] = config.list(
+    """
+    List of modules relative to the project root containing extension components.
+    """
+    packages: cfglist["packaging.requirements.Requirement"] = config.list(
         type=types.PackageRequirement(),
     )
+    """
+    List of package requirement specifiers the model depends on.
+    
+    """
     morphologies: cfglist[MorphologyDependencyNode] = config.list(
         type=types.or_(MorphologyDependencyNode, MorphologyPipelineNode),
     )
+    """
+    Morphology files and processing pipelines.
+    """
     storage: StorageNode = config.attr(
         type=StorageNode,
         required=True,
     )
+    """
+    Network storage configuration
+    """
     network: NetworkNode = config.attr(
         type=NetworkNode,
         required=True,
     )
+    """
+    Network description
+    """
     regions: cfgdict[str, Region] = config.dict(
         type=Region,
     )
+    """
+    Network regions
+    """
     partitions: cfgdict[str, Partition] = config.dict(
         type=Partition,
         required=True,
     )
+    """
+    Network partitions
+    """
     cell_types: cfgdict[str, CellType] = config.dict(
         type=CellType,
         required=True,
     )
+    """
+    Network cell types
+    """
     placement: cfgdict[str, PlacementStrategy] = config.dict(
         type=PlacementStrategy,
         required=True,
     )
+    """
+    Network placement strategies
+    """
     after_placement: cfgdict[str, PostProcessingHook] = config.dict(
         type=PostProcessingHook,
     )
@@ -101,12 +129,18 @@ class Configuration:
         type=ConnectionStrategy,
         required=True,
     )
+    """
+    Network connectivity strategies
+    """
     after_connectivity: cfgdict[str, PostProcessingHook] = config.dict(
         type=PostProcessingHook,
     )
     simulations: cfgdict[str, Simulation] = config.dict(
         type=Simulation,
     )
+    """
+    Network simulation configuration
+    """
     __module__ = "bsb.config"
 
     @classmethod

--- a/bsb/config/_config.py
+++ b/bsb/config/_config.py
@@ -150,10 +150,3 @@ class Configuration:
 
     def __repr__(self):
         return f"{type(self).__qualname__}({self})"
-
-
-def _bootstrap_components(components, file_store=None):
-    for component in components:
-        component_node = CodeDependencyNode(component)
-        component_node.file_store = file_store
-        component_node.load_object()

--- a/bsb/config/_config.py
+++ b/bsb/config/_config.py
@@ -20,6 +20,8 @@ from . import types
 from ._attrs import _boot_nodes, cfgdict, cfglist
 
 if typing.TYPE_CHECKING:
+    from packaging.requirements import Requirement
+
     from ..core import Scaffold
 
 
@@ -62,6 +64,9 @@ class Configuration:
     """
     components: cfglist[CodeDependencyNode] = config.list(
         type=CodeDependencyNode,
+    )
+    packages: cfglist["Requirement"] = config.list(
+        type=types.PackageRequirement(),
     )
     morphologies: cfglist[MorphologyDependencyNode] = config.list(
         type=types.or_(MorphologyDependencyNode, MorphologyPipelineNode),

--- a/bsb/config/_make.py
+++ b/bsb/config/_make.py
@@ -8,6 +8,7 @@ from re import sub
 
 import errr
 
+from .._package_spec import warn_missing_packages
 from ..exceptions import (
     BootError,
     CastError,
@@ -314,9 +315,10 @@ def wrap_root_postnew(post_new):
         if not hasattr(self, "_meta"):
             self._meta = {"path": None, "produced": True}
 
-        # Root node bootstrapping sequence
         try:
+            # Root node bootstrapping sequence
             _bootstrap_components(kwargs.get("components", []), file_store=_store)
+            warn_missing_packages(kwargs.get("packages", []))
         except Exception as e:
             raise BootError("Failed to bootstrap configuration.") from e
 

--- a/bsb/config/types.py
+++ b/bsb/config/types.py
@@ -764,3 +764,17 @@ class ndarray(TypeHandler):
 
     def __inv__(self, value):
         return value.tolist()
+
+
+class PackageRequirement(TypeHandler):
+    def __call__(self, value):
+        from packaging.requirements import Requirement
+
+        return Requirement(value)
+
+    @property
+    def __name__(self):
+        return "package requirement"
+
+    def __inv__(self, value):
+        return str(value)

--- a/bsb/config/types.py
+++ b/bsb/config/types.py
@@ -778,3 +778,6 @@ class PackageRequirement(TypeHandler):
 
     def __inv__(self, value):
         return str(value)
+
+    def __hint__(self):
+        return "numpy==1.24.0"

--- a/bsb/exceptions.py
+++ b/bsb/exceptions.py
@@ -138,10 +138,6 @@ class ConfigurationWarning(ScaffoldWarning):
     pass
 
 
-class UserUserDeprecationWarning(ScaffoldWarning):
-    pass
-
-
 class PlacementWarning(ScaffoldWarning):
     pass
 
@@ -162,17 +158,5 @@ class QuiverFieldWarning(ScaffoldWarning):
     pass
 
 
-class RepositoryWarning(ScaffoldWarning):
-    pass
-
-
-class SimulationWarning(ScaffoldWarning):
-    pass
-
-
-class KernelWarning(SimulationWarning):
-    pass
-
-
-class CriticalDataWarning(ScaffoldWarning):
+class PackageRequirementWarning(ScaffoldWarning):
     pass

--- a/bsb/storage/fs/file_store.py
+++ b/bsb/storage/fs/file_store.py
@@ -102,7 +102,6 @@ class FileStore(IFileStore):
         :raises Exception: When there's no active configuration in the file store.
         """
         from bsb.config import Configuration
-        from bsb.config._config import _bootstrap_components
 
         stored = self.find_meta("active_config", True)
         if stored is None:
@@ -110,8 +109,7 @@ class FileStore(IFileStore):
         else:
             content, meta = stored.load()
             tree = json.loads(content)
-            _bootstrap_components(tree.get("components", []), self)
-            cfg = Configuration(**tree)
+            cfg = Configuration(**tree, _store=self)
             cfg._meta = meta
             return cfg
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,7 @@ autodoc_mock_imports = [
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
+    "packaging": ("https://packaging.pypa.io/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://scipy.github.io/devdocs/", None),
     "errr": ("https://errr.readthedocs.io/en/latest/", None),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "tqdm~=4.50",
     "shortuuid",
     "quantities",
+    "exceptiongroup",
 ]
 
 [tool.flit.module]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ parallel = [
 ]
 test = [
     "bsb-arbor==0.0.0b1",
-    "bsb-hdf5==1.0.0b1",
+    "bsb-hdf5==1.0.0b2",
     "bsb-test==0.0.0b14",
     "coverage~=7.3",
 ]

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -432,17 +432,9 @@ class BootRoot:
     none = config.reflist(lambda r, h: h, default=None)
 
 
-def _bootstrap(cfg, scaffold):
-    for node in config.walk_nodes(cfg):
-        node.scaffold = scaffold
-        config.run_hook(node, "boot")
-    return cfg
-
-
 class TestConfigRefList(unittest.TestCase):
     def test_reflist_defaults(self):
         root = BootRoot({})
-        _bootstrap(root, None)
         self.assertEqual([], root.empty_list)
         self.assertEqual([], root.none)
 
@@ -519,7 +511,6 @@ class TestPopulate(unittest.TestCase):
         pop_root = PopRoot(
             {"lists": {}, "referrers": {"ref_cfg": "lists", "ref": "lists"}}
         )
-        _bootstrap(pop_root, None)
         self.assertEqual(1, len(pop_root.lists.cfglist), "`populate` config.list failure")
         self.assertEqual(
             pop_root.referrers,
@@ -533,7 +524,6 @@ class TestPopulate(unittest.TestCase):
 
     def test_populate_reflist(self):
         pop_root = PopRoot({"lists": {}, "referrers": {"ref_ref": "lists"}})
-        _bootstrap(pop_root, None)
         self.assertEqual(
             1, len(pop_root.lists.reflist), "`populate` config.reflist failure"
         )
@@ -549,7 +539,6 @@ class TestPopulate(unittest.TestCase):
             "referrers": {"ref_ref": "lists", "ref_ref2": "lists"},
         }
         pop_root = PopRoot(conf)
-        _bootstrap(pop_root, None)
         self.assertEqual(1, len(pop_root.lists.reflist))
         self.assertEqual(pop_root.referrers, pop_root.lists.reflist[0])
 
@@ -561,7 +550,6 @@ class TestPopulate(unittest.TestCase):
                 "referrers": {"ref_ref": "lists", "ref_ref2": "lists"},
             },
         )
-        _bootstrap(pop_root, None)
         self.assertEqual(1, len(pop_root.lists.reflist))
         self.assertEqual(pop_root.referrers, pop_root.lists.reflist[0])
 
@@ -574,7 +562,6 @@ class TestPopulate(unittest.TestCase):
                 "refs2": {"ref_ref": "lists"},
             }
         )
-        _bootstrap(pop_root, None)
         self.assertEqual(4, len(pop_root.lists.reflist))
         self.assertEqual(pop_root.referrers, pop_root.lists.reflist[0])
         HasRefs.ref_ref.pop_unique = True
@@ -583,7 +570,6 @@ class TestPopulate(unittest.TestCase):
         pop_root = PopRoot(
             {"lists": {}, "referrers": {"reflist": ["lists", "lists", "lists"]}}
         )
-        _bootstrap(pop_root, None)
         self.assertEqual(1, len(pop_root.lists.list), "Reflist did not populate uniquely")
         self.assertEqual(pop_root.referrers, pop_root.lists.list[0])
 
@@ -592,7 +578,6 @@ class TestPopulate(unittest.TestCase):
         pop_root = PopRoot(
             {"lists": {}, "referrers": {"reflist": ["lists", "lists", "lists"]}}
         )
-        _bootstrap(pop_root, None)
         self.assertEqual(3, len(pop_root.lists.list))
         self.assertEqual(pop_root.referrers, pop_root.lists.list[0])
         HasRefs.reflist.pop_unique = True

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -12,6 +12,7 @@ from bsb_test import (
 )
 
 from bsb import config
+from bsb._package_spec import get_missing_requirement_reason
 from bsb.config import Configuration, _attrs, compose_nodes, types
 from bsb.config.refs import Reference
 from bsb.core import Scaffold

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -11,6 +11,7 @@ from bsb_test import (
     list_test_configs,
 )
 
+import bsb
 from bsb import config
 from bsb._package_spec import get_missing_requirement_reason
 from bsb.config import Configuration, _attrs, compose_nodes, types
@@ -24,6 +25,7 @@ from bsb.exceptions import (
     ConfigurationWarning,
     DynamicClassInheritanceError,
     DynamicObjectNotFoundError,
+    PackageRequirementWarning,
     RequirementError,
     UnfitClassCastError,
     UnresolvedClassCastError,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1594,3 +1594,25 @@ class TestNodeComposition(unittest.TestCase):
         assert type(self.tested.attrB == config.ConfigurationAttribute)
         assert hasattr(self.tested, "attrC")
         assert type(self.tested.attrC == config.ConfigurationAttribute)
+
+
+class TestPackageRequirements(unittest.TestCase):
+    def test_basic_version(self):
+        self.assertIsNone(get_missing_requirement_reason("bsb-core==" + bsb.__version__))
+
+    def test_invalid_requirement(self):
+        self.assertIsNotNone(
+            get_missing_requirement_reason("==" + bsb.__version__ + "@@==@@")
+        )
+        with self.assertRaises(CastError):
+            Configuration.default(packages=["==" + bsb.__version__ + "@@==@@"])
+
+    def test_different_version(self):
+        self.assertIsNotNone(get_missing_requirement_reason("bsb-core==0"))
+        with self.assertWarns(PackageRequirementWarning):
+            Configuration.default(packages=["bsb-core==0"])
+
+    def test_uninstalled_package(self):
+        self.assertIsNotNone(get_missing_requirement_reason("bsb-core-soup==4.0"))
+        with self.assertWarns(PackageRequirementWarning):
+            Configuration.default(packages=["bsb-core-soup==4.0"])

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -1,13 +1,6 @@
-import json
-import os
-import random
-import string
-import sys
 import unittest
 
-import h5py
-import numpy as np
-from bsb_test import skip_nointernet, skip_parallel
+from bsb_test import RandomStorageFixture, skip_nointernet, skip_parallel
 
 from bsb.cell_types import CellType
 from bsb.config import Configuration
@@ -30,7 +23,7 @@ def spoof_combo(name, *names):
     ]
 
 
-class TestSelectors(unittest.TestCase):
+class TestSelectors(RandomStorageFixture, unittest.TestCase, engine_name="hdf5"):
     def assertPicked(self, picks, sel, loaders, msg=None):
         self.assertEqual(picks, [l.name for l in loaders if sel.pick(l)], msg=msg)
 
@@ -70,10 +63,8 @@ class TestSelectors(unittest.TestCase):
     @skip_parallel
     def test_cell_type_shorthand(self):
         ct = CellType(spatial=dict(morphologies=[{"names": "*"}]))
-        cfg = Configuration.default(
-            storage={"root": "selectors_test.hdf5"}, cell_types={"ct": ct}
-        )
-        s = Scaffold(cfg)
+        cfg = Configuration.default(cell_types={"ct": ct})
+        s = Scaffold(cfg, self.storage)
         s.morphologies.save("A", Morphology([Branch([[0, 0, 0]], [1])]), overwrite=True)
         self.assertEqual(1, len(ct.get_morphologies()), "Should select saved morpho")
         ct.spatial.morphologies[0].names = ["B"]
@@ -94,7 +85,7 @@ class TestSelectors(unittest.TestCase):
             )
         )
         cfg = Configuration.default(cell_types={"ct": ct})
-        s = Scaffold(cfg)
+        s = Scaffold(cfg, self.storage)
         self.assertIn(name, s.morphologies, "missing NM")
         m = s.morphologies.select(*ct.spatial.morphologies)[0]
         self.assertEqual(name, m.get_meta()["neuron_name"], "meta not stored")
@@ -112,7 +103,7 @@ class TestSelectors(unittest.TestCase):
             )
         )
         cfg = Configuration.default(cell_types={"ct": ct})
-        s = Scaffold(cfg)
+        s = Scaffold(cfg, self.storage)
         with self.assertRaises(SelectorError, msg="doesnt exist, should error"):
             err = None
             try:


### PR DESCRIPTION
## Describe the work done

Models can now list which packages they rely on. When a `Configuration` is instantiated in an environment that fails to meet those requirements, warnings will be raised.

## List which issues this resolves:

## Tasks

* [x] Added tests
* [ ] Updated documentation
