### PR TITLE
Output naming

### DIFF
--- a/bsb/config/types.py
+++ b/bsb/config/types.py
@@ -766,6 +766,16 @@ class ndarray(TypeHandler):
         return value.tolist()
 
 
+def none():
+    def type_handler(value, _parent, _key=None):
+        if value is not None:
+            raise TypeError("value is not None")
+        return value
+
+    type_handler.__name__ = "a None value"
+    return type_handler
+
+
 class PackageRequirement(TypeHandler):
     def __call__(self, value):
         from packaging.requirements import Requirement
@@ -806,6 +816,7 @@ __all__ = [
     "method_shortcut",
     "mut_excl",
     "ndarray",
+    "none",
     "number",
     "object_",
     "or_",

--- a/bsb/connectivity/strategy.py
+++ b/bsb/connectivity/strategy.py
@@ -5,6 +5,7 @@ from itertools import chain
 from .. import config
 from .._util import ichain, obj_str_insert
 from ..config import refs, types
+from ..exceptions import ConnectivityError
 from ..mixins import HasDependencies
 from ..profiling import node_meter
 from ..reporting import report, warn
@@ -75,6 +76,22 @@ class ConnectionStrategy(abc.ABC, HasDependencies):
     """Postsynaptic (target) neuron population"""
     depends_on: list["ConnectionStrategy"] = config.reflist(refs.connectivity_ref)
     """The list of strategies that must run before this one"""
+    output_naming: typing.Union[str, None, dict[str, dict[str, str, None, list[str]]]] = (
+        config.attr(
+            type=types.or_(
+                types.str(),
+                types.dict(
+                    type=types.dict(
+                        type=types.or_(
+                            types.str(), types.list(type=types.str()), types.none()
+                        )
+                    )
+                ),
+                types.list(type=types.str()),
+            )
+        )
+    )
+    """Specifies how to name the output ConnectivitySets in which the connections between cell type pairs are stored."""
 
     def __init_subclass__(cls, **kwargs):
         super(cls, cls).__init_subclass__(**kwargs)
@@ -112,12 +129,33 @@ class ConnectionStrategy(abc.ABC, HasDependencies):
         return pre, post
 
     def connect_cells(self, pre_set, post_set, src_locs, dest_locs, tag=None):
-        if len(self.presynaptic.cell_types) > 1 or len(self.postsynaptic.cell_types) > 1:
-            name = f"{self.name}_{pre_set.cell_type.name}_to_{post_set.cell_type.name}"
+        names = self.get_output_names(pre_set.cell_type, post_set.cell_type)
+        between_msg = f"between {pre_set.cell_type.name} and {post_set.cell_type.name}"
+        if len(names) == 0:
+            raise ConnectivityError(
+                f"Connections {between_msg} have been disabled by output naming."
+            )
+        elif len(names) == 1:
+            name = names[0]
+            if tag is not None and tag != name:
+                raise ConnectivityError(
+                    f"Tag ('{tag}') and output name ('{name}') mismatch."
+                )
         else:
-            name = self.name
+            names_msg = f"{between_msg} (names: {', '.join(names)})."
+            if tag is None:
+                raise ConnectivityError(
+                    f"No tag was given to decide between multiple output names {names_msg}"
+                )
+            elif tag not in names:
+                raise ConnectivityError(
+                    f"Tag '{tag}' is not a valid output name {names_msg}"
+                )
+            else:
+                name = tag
+
         cs = self.scaffold.require_connectivity_set(
-            pre_set.cell_type, post_set.cell_type, tag if tag is not None else name
+            pre_set.cell_type, post_set.cell_type, name
         )
         cs.connect(pre_set, post_set, src_locs, dest_locs)
 
@@ -169,6 +207,70 @@ class ConnectionStrategy(abc.ABC, HasDependencies):
         all_ps = (ct.get_placement_set() for ct in self.postsynaptic.cell_types)
         chunks = set(ichain(ps.get_all_chunks() for ps in all_ps))
         return list(chunks)
+
+    def get_output_names(self, pre=None, post=None):
+        if (pre is None) != (post is None):
+            raise RuntimeError("pre and post must be specified or omitted together.")
+        if pre is not None and (
+            pre not in self.presynaptic.cell_types
+            or post not in self.postsynaptic.cell_types
+        ):
+            raise ValueError(
+                f"'{pre.name}' and '{post.name}' are not a valid cell pair type for this connectivity strategy."
+            )
+        if self.output_naming is None or isinstance(self.output_naming, str):
+            return self._infer_output_name(self.output_naming or self.name, pre, post)
+        elif isinstance(self.output_naming, list):
+            # Call `_infer_output_name` for each given `base` in the list, and chain them together
+            return [
+                *ichain(
+                    self._infer_output_name(base, pre, post)
+                    for base in self.output_naming
+                )
+            ]
+        else:
+            return self._get_output_name(pre, post)
+
+    def _infer_output_name(self, base, pre, post):
+        if len(self.presynaptic.cell_types) > 1 or len(self.postsynaptic.cell_types) > 1:
+            if pre is None:
+                # All output names
+                return [
+                    *ichain(
+                        self._infer_output_name(base, pre_ct, post_ct)
+                        for pre_ct in self.presynaptic.cell_types
+                        for post_ct in self.postsynaptic.cell_types
+                    )
+                ]
+            else:
+                # Pair specific output name
+                return [f"{base}_{pre.name}_to_{post.name}"]
+        else:
+            # Single output name
+            return [base]
+
+    def _get_output_name(self, pre, post):
+        if pre is None:
+            # All output names
+            return [
+                *ichain(
+                    self._get_output_name(pre_ct, post_ct)
+                    for pre_ct in self.presynaptic.cell_types
+                    for post_ct in self.postsynaptic.cell_types
+                )
+            ]
+        else:
+            # Pair specific output name
+            MISSING = type("MISSING", (), {"get": lambda *args: MISSING})()
+            spec = self.output_naming.get(pre.name, MISSING).get(post.name, MISSING)
+            if spec is MISSING:
+                return self._infer_output_name(self.name, pre, post)
+            elif spec is None:
+                return []
+            elif isinstance(spec, str):
+                return [spec]
+            else:
+                return spec
 
 
 __all__ = ["ConnectionStrategy", "Hemitype", "HemitypeCollection"]

--- a/bsb/storage/interfaces.py
+++ b/bsb/storage/interfaces.py
@@ -899,7 +899,7 @@ class ConnectivitySet(Interface):
     @abc.abstractmethod
     def exists(engine, tag):
         """
-        Must check the existence of the placement set
+        Must check the existence of the connectivity set
         """
         pass
 

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -12,7 +12,15 @@ from bsb_test import (
     skip_parallel,
 )
 
-from bsb import MPI, Branch, Configuration, Morphology, Scaffold
+from bsb import (
+    MPI,
+    Branch,
+    Configuration,
+    ConnectionStrategy,
+    ConnectivityError,
+    Morphology,
+    Scaffold,
+)
 
 
 class TestAllToAll(
@@ -684,3 +692,345 @@ class TestFixedIndegree(
                 this[u] = c
                 total += this
             self.assertTrue(np.all(total == 50), "Not all cells have indegree 50")
+
+
+class TestOutputNamingSingle(unittest.TestCase):
+    """Test output naming as specified in: https://github.com/dbbs-lab/bsb-core/issues/823"""
+
+    def setUp(self):
+        super().setUp()
+        self.cfg = Configuration.default(
+            connectivity=dict(
+                x=dict(
+                    strategy="bsb.connectivity.VoxelIntersection",
+                    presynaptic=dict(cell_types=["A"]),
+                    postsynaptic=dict(cell_types=["B"]),
+                )
+            ),
+            cell_types=dict(
+                A=dict(spatial=dict(radius=1, count=1)),
+                B=dict(spatial=dict(radius=1, count=1)),
+                C=dict(spatial=dict(radius=1, count=1)),
+            ),
+        )
+
+    def test_output_naming_args(self):
+        with self.assertRaises(RuntimeError):
+            self.cfg.connectivity.x.get_output_names(pre=self.cfg.cell_types.A)
+        with self.assertRaises(RuntimeError):
+            self.cfg.connectivity.x.get_output_names(post=self.cfg.cell_types.B)
+        self.cfg.connectivity.x.get_output_names(
+            pre=self.cfg.cell_types.A, post=self.cfg.cell_types.B
+        )
+        self.cfg.connectivity.x.get_output_names()
+
+    def test_output_naming(self):
+        self.cfg.connectivity.x.output_naming = "wow"
+        self.assertEqual(["wow"], self.cfg.connectivity.x.get_output_names())
+        self.assertEqual(
+            ["wow"],
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.A, self.cfg.cell_types.B
+            ),
+        )
+
+    def test_naming_convention(self):
+        self.assertEqual(["x"], self.cfg.connectivity.x.get_output_names())
+        self.assertEqual(
+            ["x"],
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.A, self.cfg.cell_types.B
+            ),
+        )
+
+    def test_output_naming_list(self):
+        self.cfg.connectivity.x.output_naming = ["wow:type_1", "wow:type_2"]
+        self.assertEqual(
+            ["wow:type_1", "wow:type_2"], self.cfg.connectivity.x.get_output_names()
+        )
+        self.assertEqual(
+            ["wow:type_1", "wow:type_2"],
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.A, self.cfg.cell_types.B
+            ),
+        )
+
+    def test_output_naming_dict(self):
+        """Test that we can specify cell pair outputs"""
+        self.cfg.connectivity.x.output_naming = {"A": {"B": "zzz"}}
+        self.assertEqual(["zzz"], self.cfg.connectivity.x.get_output_names())
+        self.assertEqual(
+            ["zzz"],
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.A, self.cfg.cell_types.B
+            ),
+        )
+
+    def test_output_naming_dict_list(self):
+        """Test that we can specify cell pair outputs"""
+        self.cfg.connectivity.x.output_naming = {"A": {"B": ["zzz", "bb"]}}
+        self.assertEqual(["zzz", "bb"], self.cfg.connectivity.x.get_output_names())
+        self.assertEqual(
+            ["zzz", "bb"],
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.A, self.cfg.cell_types.B
+            ),
+        )
+
+    def test_output_naming_dict_blocked(self):
+        """Test that we skip nulled output names"""
+        self.cfg.connectivity.x.output_naming = {"A": {"B": None}}
+        self.assertEqual([], self.cfg.connectivity.x.get_output_names())
+        self.assertEqual(
+            [],
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.A, self.cfg.cell_types.B
+            ),
+        )
+
+    def test_output_naming_dict_missing(self):
+        """Test that we infer missing output names according to naming convention"""
+        self.cfg.connectivity.x.output_naming = {}
+        self.assertEqual(["x"], self.cfg.connectivity.x.get_output_names())
+        self.assertEqual(
+            ["x"],
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.A, self.cfg.cell_types.B
+            ),
+        )
+
+    def test_output_naming_flipped_input(self):
+        with self.assertRaises(ValueError):
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.B, self.cfg.cell_types.A
+            )
+
+    def test_output_naming_invalid_input(self):
+        with self.assertRaises(ValueError):
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.A, self.cfg.cell_types.C
+            )
+
+
+class TestOutputNamingMultiConvention(unittest.TestCase):
+    """Test output naming as specified in: https://github.com/dbbs-lab/bsb-core/issues/823"""
+
+    def setUp(self):
+        super().setUp()
+        self.cfg = Configuration.default(
+            connectivity=dict(
+                x=dict(
+                    strategy="bsb.connectivity.VoxelIntersection",
+                    presynaptic=dict(cell_types=["A", "B"]),
+                    postsynaptic=dict(cell_types=["C", "D", "E"]),
+                )
+            ),
+            cell_types=dict(
+                A=dict(spatial=dict(radius=1, count=1)),
+                B=dict(spatial=dict(radius=1, count=1)),
+                C=dict(spatial=dict(radius=1, count=1)),
+                D=dict(spatial=dict(radius=1, count=1)),
+                E=dict(spatial=dict(radius=1, count=1)),
+            ),
+        )
+
+    def test_output_naming_multi(self):
+        self.assertEqual(
+            ["x_A_to_C", "x_A_to_D", "x_A_to_E", "x_B_to_C", "x_B_to_D", "x_B_to_E"],
+            self.cfg.connectivity.x.get_output_names(),
+        )
+
+    def test_output_naming_multi_list(self):
+        self.cfg.connectivity.x.output_naming = ["base1", "base2"]
+        self.assertEqual(
+            [
+                "base1_A_to_C",
+                "base1_A_to_D",
+                "base1_A_to_E",
+                "base1_B_to_C",
+                "base1_B_to_D",
+                "base1_B_to_E",
+                "base2_A_to_C",
+                "base2_A_to_D",
+                "base2_A_to_E",
+                "base2_B_to_C",
+                "base2_B_to_D",
+                "base2_B_to_E",
+            ],
+            self.cfg.connectivity.x.get_output_names(),
+        )
+
+
+class TestOutputNamingMultiExpl(unittest.TestCase):
+    """Test output naming as specified in: https://github.com/dbbs-lab/bsb-core/issues/823"""
+
+    def setUp(self):
+        super().setUp()
+        self.cfg = Configuration.default(
+            connectivity=dict(
+                x=dict(
+                    strategy="bsb.connectivity.VoxelIntersection",
+                    presynaptic=dict(cell_types=["A", "B"]),
+                    postsynaptic=dict(cell_types=["C", "D", "E"]),
+                    output_naming=dict(
+                        A=dict(C="x_A_to_C", D="A_to_D"),
+                        B=dict(C=["B_to_C:type_1", "B_to_C:type_2", "anomalies"], D=None),
+                    ),
+                )
+            ),
+            cell_types=dict(
+                A=dict(spatial=dict(radius=1, count=1)),
+                B=dict(spatial=dict(radius=1, count=1)),
+                C=dict(spatial=dict(radius=1, count=1)),
+                D=dict(spatial=dict(radius=1, count=1)),
+                E=dict(spatial=dict(radius=1, count=1)),
+            ),
+        )
+
+    def test_output_naming_flipped_input(self):
+        with self.assertRaises(ValueError):
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.C, self.cfg.cell_types.A
+            )
+
+    def test_output_naming_invalid_input(self):
+        with self.assertRaises(ValueError):
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.A, self.cfg.cell_types.B
+            )
+
+    def test_output_naming_explicit(self):
+        self.assertEqual(
+            ["x_A_to_C"],
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.A, self.cfg.cell_types.C
+            ),
+        )
+        self.assertEqual(
+            ["A_to_D"],
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.A, self.cfg.cell_types.D
+            ),
+        )
+
+    def test_output_naming_inferred(self):
+        self.assertEqual(
+            ["x_A_to_E"],
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.A, self.cfg.cell_types.E
+            ),
+        )
+        self.assertEqual(
+            ["x_B_to_E"],
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.B, self.cfg.cell_types.E
+            ),
+        )
+
+    def test_output_naming_list(self):
+        self.assertEqual(
+            ["B_to_C:type_1", "B_to_C:type_2", "anomalies"],
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.B, self.cfg.cell_types.C
+            ),
+        )
+
+    def test_output_naming_blocked(self):
+        self.assertEqual(
+            [],
+            self.cfg.connectivity.x.get_output_names(
+                self.cfg.cell_types.B, self.cfg.cell_types.D
+            ),
+        )
+
+    def test_output_naming(self):
+        self.assertEqual(
+            [
+                "x_A_to_C",
+                "A_to_D",
+                "x_A_to_E",
+                "B_to_C:type_1",
+                "B_to_C:type_2",
+                "anomalies",
+                "x_B_to_E",
+            ],
+            self.cfg.connectivity.x.get_output_names(),
+        )
+
+
+class TestOutputNamingConnect(
+    RandomStorageFixture, NetworkFixture, unittest.TestCase, engine_name="hdf5"
+):
+    """
+    Test that connectivity sets can only be formed according to output naming as specified in:
+    https://github.com/dbbs-lab/bsb-core/issues/823
+    """
+
+    def setUp(self):
+        class Strat(ConnectionStrategy):
+            def connect(self, pre, post):
+                pass
+
+        self.cfg = Configuration.default(
+            connectivity=dict(
+                x=dict(
+                    strategy=Strat,
+                    presynaptic=dict(cell_types=["A", "B"]),
+                    postsynaptic=dict(cell_types=["C", "D", "E"]),
+                    output_naming=dict(
+                        A=dict(C="x_A_to_C", D="A_to_D"),
+                        B=dict(C=["B_to_C:type_1", "B_to_C:type_2", "anomalies"], D=None),
+                    ),
+                )
+            ),
+            cell_types=dict(
+                A=dict(spatial=dict(radius=1, count=1)),
+                B=dict(spatial=dict(radius=1, count=1)),
+                C=dict(spatial=dict(radius=1, count=1)),
+                D=dict(spatial=dict(radius=1, count=1)),
+                E=dict(spatial=dict(radius=1, count=1)),
+            ),
+        )
+        super().setUp()
+
+    def test_connect_cells_no_tag(self):
+        ps_pre = self.network.get_placement_set("A")
+        ps_post = self.network.get_placement_set("C")
+        self.network.connectivity.x.connect_cells(ps_pre, ps_post, [], [])
+        self.assertTrue(
+            self.network.storage._ConnectivitySet.exists(
+                self.network.storage._engine, "x_A_to_C"
+            )
+        )
+
+    def test_connect_cells_wrong_tag(self):
+        ps_pre = self.network.get_placement_set("A")
+        ps_post = self.network.get_placement_set("C")
+        with self.assertRaises(ConnectivityError):
+            self.network.connectivity.x.connect_cells(
+                ps_pre, ps_post, [], [], tag="wrong"
+            )
+
+    def test_connect_cells_missing_tag(self):
+        ps_pre = self.network.get_placement_set("B")
+        ps_post = self.network.get_placement_set("C")
+        with self.assertRaises(ConnectivityError):
+            self.network.connectivity.x.connect_cells(ps_pre, ps_post, [], [])
+
+    def test_connect_cells_specified_tag(self):
+        ps_pre = self.network.get_placement_set("B")
+        ps_post = self.network.get_placement_set("C")
+        self.network.connectivity.x.connect_cells(
+            ps_pre, ps_post, [], [], tag="B_to_C:type_2"
+        )
+        self.assertTrue(
+            self.network.storage._ConnectivitySet.exists(
+                self.network.storage._engine, "B_to_C:type_2"
+            )
+        )
+
+    def test_connect_cells_blocked(self):
+        ps_pre = self.network.get_placement_set("B")
+        ps_post = self.network.get_placement_set("D")
+        with self.assertRaises(ConnectivityError):
+            self.network.connectivity.x.connect_cells(ps_pre, ps_post, [], [])


### PR DESCRIPTION
The link between a connectivity strategy and the output connectivity sets that it may contribute to can now be determined in a component-based fashion by extending the `ConnectivityStrategy` interface with `get_output_names` and a configurable `output_naming`.

closes #823, with slight modifications.

## Tasks

* [x] Added tests
* [ ] Updated documentation
