### PR TITLE
Store versions in the storage objects

### DIFF
--- a/bsb/storage/interfaces.py
+++ b/bsb/storage/interfaces.py
@@ -99,6 +99,15 @@ class Engine(Interface):
 
     @property
     @abc.abstractmethod
+    def versions(self):
+        """
+        Must return a dictionary containing the version of the engine package, and bsb
+        package, used to last write to this storage object.
+        """
+        pass
+
+    @property
+    @abc.abstractmethod
     def root_slug(self):
         """
         Must return a pathlike unique identifier for the root of the storage object.


### PR DESCRIPTION
## Describe the work done

This makes it mandatory for storage engines to write the version of the BSB and the used storage engine into the storage object. This makes it much easier to know which version to use to read the stored network.

PS: This was supposed to be merged before release, but ah well.