### PR TITLE
Bump version: 4.1.0 → 4.1.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+# 4.1.1
+* Fix reference of file_ref during configuration parsing when importing nodes.
+* Use a more strict rule for Jobs enqueuing.
+* Use certifi to fix ssl certificate issues.
+
 # 4.1.0
 * Added `ParsesReferences` mixin from bsb-json to allow reference and import in configuration files.
   This includes also a recursive parsing of the configuration files.

--- a/bsb/__init__.py
+++ b/bsb/__init__.py
@@ -7,7 +7,7 @@ which are essential for `bsb-core` to function. First time users are recommended
 install the `bsb` package instead.
 """
 
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 
 import functools
 import importlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ line-length = 90
 profile = "black"
 
 [tool.bumpversion]
-current_version = "4.1.0"
+current_version = "4.1.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"


### PR DESCRIPTION
## Describe the work done
Bump to version v4.1.1.
Fixed duplication of jobs and reference of file_ref when importing nodes.

## Tasks

* [ ] Added tests
* [ ] Updated documentation
* [X] Bump version
