### PR TITLE
Fix core run functions

### DIFF
--- a/bsb/core.py
+++ b/bsb/core.py
@@ -270,7 +270,7 @@ class Scaffold:
         if pipelines:
             self.run_pipelines()
         if strategies is None:
-            strategies = [*self.placement.values()]
+            strategies = set(self.placement.values())
         strategies = PlacementStrategy.sort_deps(strategies)
         with self.create_job_pool(fail_fast=fail_fast) as pool:
             if pool.is_main():
@@ -309,7 +309,7 @@ class Scaffold:
         Run after placement hooks.
         """
         if hooks is None:
-            hooks = self.after_placement
+            hooks = set(self.after_placement.values())
         with self.create_job_pool(fail_fast) as pool:
             if pool.is_main():
                 pool.schedule(hooks)
@@ -321,7 +321,7 @@ class Scaffold:
         Run after placement hooks.
         """
         if hooks is None:
-            hooks = self.after_placement
+            hooks = set(self.after_connectivity.values())
         with self.create_job_pool(fail_fast) as pool:
             if pool.is_main():
                 pool.schedule(hooks)


### PR DESCRIPTION
## Describe the work done

- Fix the default strategy to run for ``run_after_placement`` and ``run_after_connectivity``. They were set to the strategy name instead of the strategy instances.
- Fix ``run_placement`` to match the other ``run`` functions
