### PR TITLE
Permissions needed for auto commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
     outputs:
       tag: ${{ steps.semver.outputs.next }}
       old_tag: ${{ steps.semver.outputs.current }}
+    
+
+    permissions:
+        contents: write
 
     steps:
       - name: Checkout Code
@@ -53,6 +57,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: bump
+
+    permissions:
+        contents: write
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
## Describe the work done
The auto-commit PR failed on bump action, it seemed that it lacks the permits to commit and push on main.
I have found that in the pull request demo they use a line for: # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.

It still need to be tested properly.

## Tasks

[X] Added tests

