### PR TITLE
fix: use OIDC instead of user token to publish to pypi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           branch: main
-          commit_message: 'docs: bump version: ${{ steps.semver.outputs.current }} → ${{ steps.semver.outputs.next }} [skip-ci]'
+          commit_message: 'docs: bump version: ${{ steps.semver.outputs.current }} → ${{ steps.semver.outputs.next }} [skip ci]'
 
       - name: Create tag
         uses: rickstaa/action-create-tag@v1
@@ -115,33 +115,48 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           branch: main
-          commit_message: 'docs: update CHANGELOG.md for ${{ github.ref_name }} [skpi ci]'
+          commit_message: 'docs: update CHANGELOG.md for ${{ github.ref_name }} [skip ci]'
           file_pattern: CHANGELOG.md
 
-  deploy:
+  pypi-publish:
     runs-on: ubuntu-latest
     needs: release
-
+    environment:
+      name: pypi
+      url: https://pypi.org/p/bsb-core
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v4
+      - name: Create Github token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.DBBS_APP_ID }}
+          private-key: ${{ secrets.DBBS_APP_PRIVATE_KEY }}
+
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Pull commits of version bump
+        run: |
+          git pull origin main
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
           python-version: 3.11
 
-      - name: Install dependencies
+      - name: Install dependencies and build dist
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
-
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
+          pip install build
           python -m build
-          twine upload --verbose --repository pypi dist/*
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   deploy_ebrains:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Describe the work done

- Fix `[skip ci]` typos
- Add OIDC setup for ``dbbs-lab/bsb-core`` on ``pypi`` linked to ``main.yml``
- Change twine to ``pypa/gh-action-pypi-publish``  
- Pull automatic commits before building 

## List which issues this resolves:
 closes #876 


