### PR TITLE
fix:  Make simulation data placement restricted to chunk

### DIFF
--- a/bsb/simulation/adapter.py
+++ b/bsb/simulation/adapter.py
@@ -50,7 +50,8 @@ class SimulationData:
         self.chunks = None
         self.populations = dict()
         self.placement: dict["CellModel", "PlacementSet"] = {
-            model: model.get_placement_set() for model in simulation.cell_models.values()
+            model: model.get_placement_set(chunks=simdata.chunks)
+            for model in simulation.cell_models.values()
         }
         self.connections = dict()
         self.devices = dict()


### PR DESCRIPTION
## Describe the work done

simdata.placement[model]  store positions for all the cell models but is gonna use only the positions of chunks, so could be better to restrict to selected chunks upon creation.

## List which issues this resolves:
closes dbbs-lab/bsb-neuron#18

## Tasks

* [X] Added tests

