### PR TITLE
fix: count_ratio on non overlapping partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/dbbs-lab/bsb-core/actions/workflows/build.yml/badge.svg)](https://github.com/dbbs-lab/bsb-core/actions/workflows/build.yml)
+[![Build Status](https://github.com/dbbs-lab/bsb-core/actions/workflows/main.yml/badge.svg)](https://github.com/dbbs-lab/bsb-core/actions/workflows/main.yml)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Documentation Status](https://readthedocs.org/projects/bsb/badge/?version=latest)](https://bsb.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/dbbs-lab/bsb-core/branch/main/graph/badge.svg)](https://codecov.io/gh/dbbs-lab/bsb-core)

--- a/bsb/placement/arrays.py
+++ b/bsb/placement/arrays.py
@@ -83,7 +83,7 @@ class ParallelArrayPlacement(NotParallel, PlacementStrategy):
                     cells[(i * len(x)) : ((i + 1) * len(x)), 1] = y
                     cells[(i * len(x)) : ((i + 1) * len(x)), 2] = z
                 # Place all the cells in 1 batch (more efficient)
-                positions = cells[cells[:, 0] < width - radius]
+                positions = cells[cells[:, 0] < prt.data.ldc[0] + width - radius]
 
                 # Determine in which chunks the cells must be placed
                 cs = self.scaffold.configuration.network.chunk_size

--- a/bsb/placement/indicator.py
+++ b/bsb/placement/indicator.py
@@ -97,12 +97,10 @@ class PlacementIndicator:
             relation = relative_to
             if count_ratio is not None:
                 strats = self._strat.scaffold.get_placement_of(relation)
-                estimate = (
-                    sum(
-                        PlacementIndicator(s, relation).guess(chunk, voxels)
-                        for s in strats
-                    )
-                    * count_ratio
+                estimate = self._estim_for_chunk(
+                    chunk,
+                    sum(PlacementIndicator(s, relation).guess() for s in strats)
+                    * count_ratio,
                 )
             elif density_ratio is not None:
                 # Create an indicator based on this strategy for the related CT.

--- a/bsb/placement/indicator.py
+++ b/bsb/placement/indicator.py
@@ -20,6 +20,7 @@ class PlacementIndications:
     density: float = config.attr(type=float)
     planar_density: float = config.attr(type=float)
     count_ratio: float = config.attr(type=float)
+    local_count_ratio: float = config.attr(type=float)
     density_ratio: float = config.attr(type=float)
     relative_to: "CellType" = config.ref(refs.cell_type_ref)
     count: int = config.attr(type=int)
@@ -87,6 +88,7 @@ class PlacementIndicator:
         relative_to = self.indication("relative_to")
         density_ratio = self.indication("density_ratio")
         count_ratio = self.indication("count_ratio")
+        local_count_ratio = self.indication("local_count_ratio")
         if count is not None:
             estimate = self._estim_for_chunk(chunk, count)
         if density is not None:
@@ -96,11 +98,26 @@ class PlacementIndicator:
         if relative_to is not None:
             relation = relative_to
             if count_ratio is not None:
+                # The total counts of cell of the current strategy is a ratio
+                # of the total number of cell placed by the target strategy.
+                # This number is uniformly distributed across the current
+                # strategy's partition(s).
                 strats = self._strat.scaffold.get_placement_of(relation)
                 estimate = self._estim_for_chunk(
                     chunk,
                     sum(PlacementIndicator(s, relation).guess() for s in strats)
                     * count_ratio,
+                )
+            elif local_count_ratio is not None:
+                # This count estimate is the ratio of the number of cell of the
+                # target strategy that were placed in the current chunk.
+                strats = self._strat.scaffold.get_placement_of(relation)
+                estimate = (
+                    sum(
+                        PlacementIndicator(s, relation).guess(chunk, voxels)
+                        for s in strats
+                    )
+                    * local_count_ratio
                 )
             elif density_ratio is not None:
                 # Create an indicator based on this strategy for the related CT.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,6 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
-    "sphinx.ext.imgmath",
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",

--- a/docs/placement/intro.rst
+++ b/docs/placement/intro.rst
@@ -1,0 +1,141 @@
+=========
+Placement
+=========
+This block in the configuration is responsible for placing cells into partitions.
+All placement strategies derive from the :class:`~.placement.strategy.PlacementStrategy` class,
+and should provide functions to define the positions of each ``CellType`` within a ``Partition`` volume.
+
+BSB offers several built-in strategies (here is a :doc:`list </placement/placement-strategies>`),
+or you can implement your own.
+The placement data is stored in :doc:`PlacementSets </placement/placement-set>` for each cell type.
+
+Add a placement strategy
+========================
+
+In the ``placement`` block, all placement strategies are defined. For each strategy,
+it is necessary to specify the references to their related :guilabel:`partitions` and :guilabel:`cell_types`
+with the corresponding attributes.
+
+.. tab-set-code::
+
+    .. code-block:: json
+
+
+        "placement": {
+            "place_A_in_my_layer": {
+                "strategy": "bsb.placement.RandomPlacement",
+                "partitions": [
+                    "my_layer"
+                ],
+                "cell_types": [
+                    "A_type"
+                ]
+            }
+        }
+
+    .. code-block:: python
+
+      config.placement.add(
+        "place_A_in_my_layer",
+        strategy="bsb.placement.RandomPlacement",
+        partitions=["my_layer"],
+        cell_types=["A_type"],
+      )
+
+
+Use indications
+===============
+
+When a cell type is created, it is possible to define spatial attributes called
+:doc:`placement indications</placement/placement-indicators>`.
+These attributes are used by the placement strategy to determine the distribution of cells within the volume.
+
+.. tab-set-code::
+
+    .. code-block:: json
+
+        "cell_types": {
+            "A_type": {
+                "spatial": {
+                    "density": 0.005,
+                    "radius": 2.5
+                }
+            },
+            "B_type": {
+                "spatial": {
+                    "count": 50,
+                    "radius": 5
+                }
+            }
+        }
+
+        "placement": {
+            "place_A_and_B_in_my_layer": {
+                "strategy": "bsb.placement.RandomPlacement",
+                "partitions": [
+                    "my_layer"
+                ],
+                "cell_types": [
+                    "A_type","B_type"
+                ]
+            }
+        }
+
+    .. code-block:: python
+
+      config.cell_types.add(
+        "A_type",
+        spatial=dict(radius=2.5, density=0.005)
+      )
+      config.cell_types.add(
+        "B_type",
+        spatial=dict(radius=5, count=50)
+      )
+
+      config.placement.add(
+        "place_A_and_B_in_my_layer",
+        strategy="bsb.placement.RandomPlacement",
+        partitions=["my_layer"],
+        cell_types=["A_type","B_type"],
+      )
+
+In this example, type A cells are placed with a density of 0.005 cells/µm^3,
+while we place 50 type B cells with a radius of 5 µm.
+
+
+Add dependencies to Placement Strategies
+========================================
+
+It may be necessary to place a set of cells only after specific strategies have been executed.
+In such cases, you can define a list of strategies as dependencies.
+For example, you can create a :guilabel:`secondary_placement` that is executed only after the
+:guilabel:`place_A_and_B_in_my_layer` placement has been completed.
+
+
+.. tab-set-code::
+
+    .. code-block:: json
+
+
+        "placement": {
+            "secondary_placement": {
+                "strategy": "bsb.placement.RandomPlacement",
+                "partitions": [
+                    "my_layer"
+                ],
+                "cell_types": [
+                    "C_type"
+                ],
+                "depends_on": ["place_A_and_B_in_my_layer"]
+            }
+        }
+
+    .. code-block:: python
+
+      config.placement.add(
+        "secondary_placement",
+        strategy="bsb.placement.RandomPlacement",
+        partitions=["my_layer"],
+        cell_types=["C_type"],
+        depends_on=["place_A_and_B_in_my_layer"],
+      )

--- a/docs/placement/placement-indicators.rst
+++ b/docs/placement/placement-indicators.rst
@@ -51,6 +51,8 @@ And then, you can choose one of the following attributes:
 
 * :guilabel:`count_ratio`: Compute the number of cells to place from the ratio between the current cell type
   and a reference cell type.
+* :guilabel:`local_count_ratio`: Same as ``count_ratio`` but applied only on chunks that the current cell type and the
+  reference cell type have in common.
 * :guilabel:`density_ratio`: Similar to ``count_ratio`` but use density instead of cell count.
 
 .. note::

--- a/docs/placement/placement-indicators.rst
+++ b/docs/placement/placement-indicators.rst
@@ -1,0 +1,157 @@
+#####################
+Placement Indications
+#####################
+
+`Placement indications` are a subpart of the a ``CellType`` configuration (attribute ``spatial`` of :doc:`/cells/intro`)
+and is leveraged to specify properties during `placement strategies` (see :doc:`/placement/placement-strategies`).
+These indications can be either related to the cell type itself (e.g. its soma radius) or
+allow for the estimation of the number of cells to place in their respective partitions.
+
+
+General cell properties
+-----------------------
+These attributes are related to the ``CellType``; among them, only ``radius`` is mandatory:
+
+* :guilabel:`radius`: The radius of the sphere used to approximate cell soma volume.
+* :guilabel:`geometry`: dict = config.dict(type=types.any_())
+* :guilabel:`morphologies`: List of morphologies references.
+
+Cell counts estimation properties
+---------------------------------
+The following attributes allow you to set the strategy used to estimate the counts of cell to place in each partition.
+You can choose either to compute the counts independently or with respect to another placement counts.
+
+.. warning::
+    BSB rounds the number of cells to place in each partition's chunk. The rounding is stochastic, therefore you
+    might not get the same counts of cells for two similar reconstructions.
+
+Independent counts estimation strategies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can choose one of the following attributes to estimate the number of cells to place in its partition(s).
+
+* :guilabel:`count`: Set directly the number of cells to place.
+* :guilabel:`density`: Use a density of cell per unit of volume (in cell/um^-3). This will be converted to counts
+  based on the partition(s) total volume.
+* :guilabel:`planar_density`: Use a density of cell along the `xy` plane per unit of area (in cell/um^-2). Here too,
+  density is converted to counts thanks to the partition(s) area along the `xy` plane.
+* :guilabel:`density_key`: Leverage a density file, defined here with a reference to a `partitions.keys`
+  (see `Voxels` section in :doc:`/topology/partitions`). The number of cells is derived from this volumetric density
+  file for each of its voxels.
+
+Relative counts estimation strategies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These strategies derives the counts of cells to place from on another ``CellType`` placement. You would need therefore
+to specify the cell name as a reference:
+
+* :guilabel:`relative_to`: Reference to a ``CellType``.
+
+And then, you can choose one of the following attributes:
+
+* :guilabel:`count_ratio`: Compute the number of cells to place from the ratio between the current cell type
+  and a reference cell type.
+* :guilabel:`density_ratio`: Similar to ``count_ratio`` but use density instead of cell count.
+
+.. note::
+    You can mix counts and densities:
+    For instance, you can have a cell A which counts is relative to the one of another cell type B, and B being defined
+    from a density value.
+
+
+Full example
+~~~~~~~~~~~~
+
+.. tab-set-code::
+
+    .. code-block:: json
+
+        "regions": {
+            "my_region": {
+                "type": "stack",
+                "children": ["my_layer", "my_second_layer"],
+            }
+        }
+        "partitions": {
+            "my_layer": {
+                "thickness": 100
+            },
+            "my_second_layer": {
+                "thickness": 200
+            },
+        }
+        "cell_types": {
+            "A": {
+                "spatial": {
+                    "count": 10,
+                    "radius": 2
+                }
+            },
+            "B": {
+                "spatial": {
+                    "relative_to": "A",
+                    "density_ratio": 1.5,
+                    "radius": 3
+                }
+            }
+        },
+
+        "placement": {
+            "place_A":{
+                "strategy": "bsb.placement.RandomPlacement",
+                "partitions": ["my_layer"],
+                "cell_types": ["A"],
+            },
+            "place_B":{
+                "strategy": "bsb.placement.RandomPlacement",
+                "partitions": ["my_second_layer"],
+                "cell_types": ["B"],
+            }
+        },
+
+    .. code-block:: python
+
+      config.partitions.add("my_layer", type="layer", thickness=100)
+      config.partitions.add("my_second_layer", type="layer", thickness=200)
+      config.regions.add(
+        "my_region",
+        type="stack",
+        children=["my_layer", "my_second_layer"]
+      )
+
+      config.cell_types.add(
+        "A",
+        spatial=dict(radius=2, count=10)
+      )
+      config.cell_types.add(
+        "B",
+        spatial=dict(radius=3, relative_to="A", density_ratio=1.5)
+      )
+
+      config.placement.add(
+        "place_A",
+        strategy="bsb.placement.RandomPlacement",
+        partitions=["my_layer"],
+        cell_types=["A"],
+      )
+      config.placement.add(
+        "place_B",
+        strategy="bsb.placement.RandomPlacement",
+        partitions=["my_second_layer"],
+        cell_types=["B"],
+      )
+
+The example configuration above creates two Layer partitions (``my_layer`` and ``my_second_layer``)
+and assigns a random position to ``A`` and ``B`` within their respective layer.
+Assuming that ``my_layer`` is big enough to contains both cells
+(see :doc:`RandomPlacement strategy</placement/placement-strategies>`), this will place 10 ``A`` and 30
+``B`` because the volume of ``my_second_layer`` :math:`v_2` is twice the one of ``my_layer`` :math:`v_1`
+and so:
+
+.. math::
+    \begin{split}
+    counts_{B} & = density_{A} \cdot 1.5 \cdot v_2 \\
+    & = \dfrac{10}{v_1} \cdot 1.5 \cdot 2 \cdot v_1 \\
+    & = 10 \cdot 1.5 \cdot 2 \\
+    & = 30
+    \end{split}

--- a/docs/placement/placement-strategies.rst
+++ b/docs/placement/placement-strategies.rst
@@ -2,38 +2,139 @@
 List of placement strategies
 ############################
 
-RandomPlacement
-*****************
+:class:`RandomPlacement <.placement.random.RandomPlacement>`
+============================================================
 
-*Class*: :class:`bsb.placement.RandomPlacement <.placement.random.RandomPlacement>`
+This class assigns a random position to each cell within their related partition. Below is an example with 10 cells.
+
+.. tab-set-code::
+
+    .. code-block:: json
+
+        "cell_types": {
+            "my_cell": {
+                "spatial": {
+                    "count": 10,
+                    "radius": 5
+                }
+            }
+        },
+
+        "placement": {
+            "place_randomly":{
+                "strategy": "bsb.placement.particle.RandomPlacement",
+                "partitions": ["my_layer"],
+                "cell_types": ["my_cell"]
+            }
+        },
+
+    .. code-block:: python
+
+      config.cell_types.add(
+        "my_cell",
+        spatial=dict(radius=5, count=10)
+      )
+      config.placement.add(
+        "place_randomly",
+        strategy="bsb.placement.RandomPlacement",
+        partitions=["my_layer"],
+        cell_types=["my_cell"],
+      )
+
+.. note::
+ This strategy will ensure that the cell somas (represented as sphere)
+ do not occupy an excessive volume with respect to their containing partition.
+ Therefore, the ratio of the total cell soma volume to the partition volume, referred as the `packing factor`,
+ should not exceed 0.4.
+
+:class:`ParallelArrayPlacement <.placement.arrays.ParallelArrayPlacement>`
+==========================================================================
+
+This class places a single layer of cells on the `xy` plane in an aligned array fashion.
+To this end, it create a lattice with fixed spacing between cell positions for each of its row (``spacing_x`` in µm).
+The lattice can be additionally rotated along the `z` axis (``angle`` defined in degrees).
+
+.. tab-set-code::
+
+    .. code-block:: json
+
+        "cell_types": {
+            "my_cell": {
+                "spatial": {
+                    "count": 100,
+                    "radius": 1
+                }
+            }
+        },
+
+        "placement": {
+            "place_on_flat_array":{
+                "strategy": "bsb.placement.ParallelArrayPlacement",
+                "partitions": ["my_layer"],
+                "cell_types": ["my_cell"],
+                "spacing_x": 10,
+                "angle": 0
+            }
+        },
+
+    .. code-block:: python
+
+      config.cell_types.add(
+        "my_cell",
+        spatial=dict(radius=1, count=100)
+      )
+      config.placement.add(
+        "place_on_flat_array",
+        strategy="bsb.placement.ParallelArrayPlacement",
+        partitions=["my_layer"],
+        cell_types=["my_cell"],
+        spacing_x=10,
+        angle=0
+      )
 
 
-ParallelArrayPlacement
-**********************
+:class:`FixedPositions <.placement.strategy.FixedPositions>`
+============================================================
 
-*Class*: :class:`bsb.placement.ParallelArrayPlacement
-<.placement.arrays.ParallelArrayPlacement>`
-
-FixedPositions
-**************
-
-*Class*: :class:`bsb.placement.FixedPositions <.placement.strategy.FixedPositions>`
-
-This class places the cells in fixed positions specified in the attribute ``positions``.
+This class places the cells at fixed positions specified by the attribute ``positions``.
 
 * ``positions``: a list of 3D points where the neurons should be placed. For example:
 
-.. code-block:: json
+.. tab-set-code::
 
-  {
-    "cell_types": {
-      "golgi_cell": {
+    .. code-block:: json
+
+        "cell_types": {
+            "my_cell": {
+                "spatial": {
+                    "count": 2,
+                    "radius": 2
+                }
+            }
+        },
+
         "placement": {
-          "class": "bsb.placement.FixedPositions",
-          "layer": "granular_layer",
-          "count": 1,
-          "positions": [[40.0,0.0,-50.0]]
-          }
-      },
-    }
-  }
+            "place_in_fixed_position":{
+                "strategy": "bsb.placement.FixedPositions",
+                "partitions": ["my_layer"],
+                "cell_types": ["my_cell"],
+                "positions": [[0, 0, 0], [20, 20, 20]]
+            }
+        },
+
+    .. code-block:: python
+
+      config.cell_types.add(
+        "my_cell",
+        spatial=dict(radius=2, count=2)
+      )
+      config.placement.add(
+        "place_in_fixed_position",
+        strategy="bsb.placement.FixedPositions",
+        partitions=["my_layer"],
+        cell_types=["my_cell"],
+        positions=[[0, 0, 0], [20, 20, 20]]
+      )
+
+In this case, we place two cells of type ``my_cell`` at fixed positions
+with coordinates [0, 0, 0] and [20, 20, 20].

--- a/docs/placement/placement-toc.rst
+++ b/docs/placement/placement-toc.rst
@@ -2,5 +2,7 @@
    :maxdepth: 2
    :caption: Placement
 
+   intro
    placement-strategies
+   placement-indicators
    placement-set


### PR DESCRIPTION
## Describe the work done
Make sure the volume ratio computation depends on the relative cell instead of the target cell. 

## List which issues this resolves:
fix #885, #889

## Tasks

* [x] Added tests


<!-- readthedocs-preview bsb start -->
----
📚 Documentation preview 📚: https://bsb--886.org.readthedocs.build/en/886/

<!-- readthedocs-preview bsb end -->