### PR TITLE
fix: Update configuration to store whenever an attribute is set

### DIFF
--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -755,6 +755,7 @@ class cfgdict(builtins.dict):
                 f"{self.get_node_name()} already contains '{key}'."
                 + " Use `node[key] = value` if you want to overwrite it."
             )
+        self._config_attr.flag_dirty(self._config_parent)
         self[key] = value = self._elem_type(*args, _parent=self, _key=key, **kwargs)
         return value
 

--- a/bsb/config/_attrs.py
+++ b/bsb/config/_attrs.py
@@ -664,6 +664,7 @@ class ConfigurationListAttribute(ConfigurationAttribute):
 
     def __set__(self, instance, value, _key=None):
         _setattr(instance, self.attr_name, self.fill(value, _parent=instance))
+        self.flag_dirty(instance)
 
     def __populate__(self, instance, value, unique_list=False):
         cfglist = _getattr(instance, self.attr_name)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1609,6 +1609,29 @@ class TestScripting(RandomStorageFixture, unittest.TestCase, engine_name="fs"):
         Scaffold(cfg, self.storage)
         self.assertIsNotNone(_attrs._booted_root(cfg), "now it should be booted")
 
+    def test_updates(self):
+        """Test if tree is updated correctly"""
+        cfg = Configuration.default()
+        cfg.morphologies = ["dummy_neuron.swc"]
+        cfg.simulations.add(
+            "neuronsim",
+            simulator="neuron",
+            resolution=0.025,
+            duration=1,
+            temperature=32,
+            cell_models={},
+            connection_models={},
+            devices={},
+        )
+        cfg_dict = cfg.__tree__()
+        self.assertEqual(cfg_dict["morphologies"], ["dummy_neuron.swc"])
+        self.assertEqual(cfg_dict["simulations"]["neuronsim"]["simulator"], "neuron")
+        cfg.morphologies = []
+        cfg.simulations.pop("neuronsim")
+        cfg_dict = cfg.__tree__()
+        self.assertEqual(cfg_dict["morphologies"], [])
+        self.assertEqual(cfg_dict["simulations"], {})
+
 
 class TestNodeClass(unittest.TestCase):
     def test_standalone_node_name(self):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1613,24 +1613,24 @@ class TestScripting(RandomStorageFixture, unittest.TestCase, engine_name="fs"):
         """Test if tree is updated correctly"""
         cfg = Configuration.default()
         cfg.morphologies = ["dummy_neuron.swc"]
-        cfg.simulations.add(
-            "neuronsim",
-            simulator="neuron",
-            resolution=0.025,
-            duration=1,
-            temperature=32,
-            cell_models={},
-            connection_models={},
-            devices={},
+        cfg.partitions.add("base_layer", thickness=100)
+        cfg.partitions.add("top_layer", thickness=100)
+        cfg.regions.add(
+            "brain_region",
+            type="stack",
+            children=[
+                "base_layer",
+                "top_layer",
+            ],
         )
         cfg_dict = cfg.__tree__()
         self.assertEqual(cfg_dict["morphologies"], ["dummy_neuron.swc"])
-        self.assertEqual(cfg_dict["simulations"]["neuronsim"]["simulator"], "neuron")
+        self.assertIn("brain_region", cfg_dict["regions"])
         cfg.morphologies = []
-        cfg.simulations.pop("neuronsim")
+        cfg.regions.pop("brain_region")
         cfg_dict = cfg.__tree__()
         self.assertEqual(cfg_dict["morphologies"], [])
-        self.assertEqual(cfg_dict["simulations"], {})
+        self.assertEqual(cfg_dict["regions"], {})
 
 
 class TestNodeClass(unittest.TestCase):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1626,7 +1626,7 @@ class TestScripting(RandomStorageFixture, unittest.TestCase, engine_name="fs"):
         cfg_dict = cfg.__tree__()
         self.assertEqual(cfg_dict["morphologies"], ["dummy_neuron.swc"])
         self.assertIn("brain_region", cfg_dict["regions"])
-        cfg.morphologies = []
+        cfg.morphologies.pop(0)
         cfg.regions.pop("brain_region")
         cfg_dict = cfg.__tree__()
         self.assertEqual(cfg_dict["morphologies"], [])


### PR DESCRIPTION
## Describe the work done

Configuration object method  ``_config_attr_order`` is updated when an attribute is set using flag_dirty.

## List which issues this resolves:

closes #899 

## Tasks

* [X] Added tests
* [X] Code
