### PR TITLE
fix: ref parsing when key is deep

### DIFF
--- a/bsb/config/_parse_types.py
+++ b/bsb/config/_parse_types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from .. import warn
-from ..exceptions import ConfigurationWarning, FileImportError
+from ..exceptions import ConfigurationWarning, FileImportError, ParserError
 
 
 class parsed_node:
@@ -163,12 +163,12 @@ class file_imp(file_ref):
                     # It should be here because of the merge.
                     loc_node = node
                     while node_loc != ref.key_path:
-                        key = ref.key_path.split(node_loc, 1)[-1].split("/", 1)[-1]
+                        key = ref.key_path.split(node_loc, 1)[-1].split("/", 2)[1]
                         if key not in loc_node:  # pragma: nocover
                             raise ParserError(
                                 f"Reference {ref.key_path} not found in {node_loc}. "
                                 f"Should have been merged."
                             )
-                        loc_node = node[key]
+                        loc_node = loc_node[key]
                         node_loc += "/" + key
                     ref.node = loc_node

--- a/tests/data/configs/outdoc_import_merge.txt
+++ b/tests/data/configs/outdoc_import_merge.txt
@@ -1,6 +1,12 @@
 {
     "imp": {
         "importable":{
+            "dicts":{
+                "$import": {
+                "ref": "indoc_reference.txt#/get/a/nested secrets",
+                "values": ["vim"]
+                },
+            },
             "$import": {
                 "ref": "indoc_import.txt#/imp/importable",
                 "values": ["dicts"]

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -248,6 +248,7 @@ class TestFileImport(unittest.TestCase):
                     "that": "are",
                     "even": {"nested": "eh"},
                     "with": ["new", "list"],
+                    "vim": "is hard",
                 },
                 "diff": "added",
             },


### PR DESCRIPTION
## Describe the work done
Fix ref parsing when the key is deep: has more than 2 "/"

## Tasks

* [x] Added tests
