### PR TITLE
feat: expose unique labels of PlacementSet

### DIFF
--- a/bsb/_encoding.py
+++ b/bsb/_encoding.py
@@ -103,8 +103,19 @@ class EncodedLabels(np.ndarray):
         else:
             raise IndexError(f"Labelset {labels} does not exist")
 
-    def get_mask(self, labels):
-        has_any = [k for k, v in self.labels.items() if any(lbl in v for lbl in labels)]
+    def get_mask(self, labels=None):
+        """
+        Get indexes matching the labels provided.
+
+        :param list[str] labels: List of labels
+        :rtype: numpy.ndarray[int]
+        """
+        labels = set(labels or [])
+        has_any = [
+            k
+            for k, v in self.labels.items()
+            if any(lbl in v for lbl in labels) or v == labels
+        ]
         return np.isin(self, has_any)
 
     def walk(self):

--- a/bsb/storage/interfaces.py
+++ b/bsb/storage/interfaces.py
@@ -628,27 +628,40 @@ class PlacementSet(Interface):
         """
         Should label the cells with given labels.
 
-        :param cells: Array of cells in this set to label.
-        :type cells: numpy.ndarray
         :param labels: List of labels
         :type labels: list[str]
+        :param cells: Array of cells in this set to label.
+        :type cells: list[int]
         """
         pass
 
     @abc.abstractmethod
-    def get_labelled(self, labels):
+    def get_unique_labels(self):
+        """
+        Should return the unique labels assigned to the cells.
+
+        :return: List of unique labels
+        :rtype: list[set[str]]
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_labelled(self, labels=None):
         """
         Should return the ids of the cells labelled with given labels.
+        If labels are not provided, will filter non labelled cells.
 
         :param labels: List of labels
         :type labels: list[str]
+        :rtype: numpy.ndarray[int]
         """
         pass
 
     @abc.abstractmethod
-    def get_label_mask(self, labels):
+    def get_label_mask(self, labels=None):
         """
         Should return a mask that fits the placement set for the cells with given labels.
+        If labels are not provided, will filter non labelled cells.
 
         :param labels: List of labels
         :type labels: list[str]


### PR DESCRIPTION
## Describe the work done
- Expose unique labels of PlacementSet
- Allow to filter non labelled placement sets

Requires bsb-hdf5 and bsb-test to be merged too.
https://github.com/dbbs-lab/bsb-hdf5/pull/42
https://github.com/dbbs-lab/bsb-test/pull/12

## Tasks

* [x] Added tests
* [x] Updated documentation
